### PR TITLE
sb600spi: Add support for Merlin Falcon Chipset

### DIFF
--- a/chipset_enable.c
+++ b/chipset_enable.c
@@ -1492,6 +1492,7 @@ const struct penable chipset_enables[] = {
 	{0x1022, 0x7440, OK,  "AMD", "AMD-768",				enable_flash_amd_768_8111},
 	{0x1022, 0x7468, OK,  "AMD", "AMD-8111",			enable_flash_amd_768_8111},
 	{0x1022, 0x780e, OK,  "AMD", "FCH",				enable_flash_sb600},
+	{0x1022, 0x790e, OK,  "AMD", "FP4",				enable_flash_sb600},
 	{0x1039, 0x0406, NT,  "SiS", "501/5101/5501",			enable_flash_sis501},
 	{0x1039, 0x0496, NT,  "SiS", "85C496+497",			enable_flash_sis85c496},
 	{0x1039, 0x0530, OK,  "SiS", "530",				enable_flash_sis530},


### PR DESCRIPTION
This patch has been tested on a board similar to AMD Bettong.

00:14.0 SMBus [0c05]: Advanced Micro Devices, Inc. [AMD] FCH SMBus
Controller [1022:790b] (rev 4a)
00:14.3 ISA bridge [0601]: Advanced Micro Devices, Inc. [AMD] FCH LPC
Bridge [1022:790e] (rev 11)
root@qt5022-fglrx:~# ./flashrom -p internal -w kk.rom

flashrom v0.9.9-unknown on Linux 4.10.0-qtec-standard (x86_64)
flashrom is free software, get the source code at
https://flashrom.org

Calibrating delay loop... OK.
coreboot table found at 0x9ffd6000.
Found chipset "AMD FP4".
Enabling flash write... OK.
Found Micron/Numonyx/ST flash chip "N25Q128..1E" (16384 kB, SPI)
mapped at physical address 0x00000000ff000000.
Reading old flash chip contents... done.
Erasing and writing flash chip... Erase/write done.
Verifying flash... VERIFIED.

Signed-off-by: Ricardo Ribalda Delgado <ricardo.ribalda@gmail.com>