### PR TITLE
nicintel_spi: Support for I210/I211 cards

### DIFF
--- a/nicintel_spi.c
+++ b/nicintel_spi.c
@@ -77,6 +77,8 @@
 // #define FL_BUSY	30
 // #define FL_ER	31
 
+#define BIT(x) (1<<(x))
+
 uint8_t *nicintel_spibar;
 
 const struct dev_entry nics_intel_spi[] = {
@@ -114,11 +116,11 @@ static void nicintel_request_spibus(void)
 	uint32_t tmp;
 
 	tmp = pci_mmio_readl(nicintel_spibar + FLA);
-	tmp |= 1 << FL_REQ;
+	tmp |= BIT(FL_REQ);
 	pci_mmio_writel(tmp, nicintel_spibar + FLA);
 
 	/* Wait until we are allowed to use the SPI bus. */
-	while (!(pci_mmio_readl(nicintel_spibar + FLA) & (1 << FL_GNT))) ;
+	while (!(pci_mmio_readl(nicintel_spibar + FLA) & BIT(FL_GNT))) ;
 }
 
 static void nicintel_release_spibus(void)
@@ -126,7 +128,7 @@ static void nicintel_release_spibus(void)
 	uint32_t tmp;
 
 	tmp = pci_mmio_readl(nicintel_spibar + FLA);
-	tmp &= ~(1 << FL_REQ);
+	tmp &= ~BIT(FL_REQ);
 	pci_mmio_writel(tmp, nicintel_spibar + FLA);
 }
 
@@ -135,7 +137,7 @@ static void nicintel_bitbang_set_cs(int val)
 	uint32_t tmp;
 
 	tmp = pci_mmio_readl(nicintel_spibar + FLA);
-	tmp &= ~(1 << FL_CS);
+	tmp &= ~BIT(FL_CS);
 	tmp |= (val << FL_CS);
 	pci_mmio_writel(tmp,  nicintel_spibar + FLA);
 }
@@ -145,7 +147,7 @@ static void nicintel_bitbang_set_sck(int val)
 	uint32_t tmp;
 
 	tmp = pci_mmio_readl(nicintel_spibar + FLA);
-	tmp &= ~(1 << FL_SCK);
+	tmp &= ~BIT(FL_SCK);
 	tmp |= (val << FL_SCK);
 	pci_mmio_writel(tmp, nicintel_spibar + FLA);
 }
@@ -155,7 +157,7 @@ static void nicintel_bitbang_set_mosi(int val)
 	uint32_t tmp;
 
 	tmp = pci_mmio_readl(nicintel_spibar + FLA);
-	tmp &= ~(1 << FL_SI);
+	tmp &= ~BIT(FL_SI);
 	tmp |= (val << FL_SI);
 	pci_mmio_writel(tmp, nicintel_spibar + FLA);
 }
@@ -225,18 +227,18 @@ static int nicintel_spi_i210_enable_flash()
 	uint32_t tmp;
 
 	tmp = pci_mmio_readl(nicintel_spibar + FLA);
-	if (tmp & (1 << FL_LOCKED)) {
+	if (tmp & BIT(FL_LOCKED)) {
 		msg_perr("Flash is in Secure Mode. Abort.\n");
 		return 1;
 	}
 
-	if (!(tmp & (1 << FL_ABORT)))
+	if (!(tmp & BIT(FL_ABORT)))
 		return 0;
 
-	tmp |= (1 << FL_CLR_ERR);
+	tmp |= BIT(FL_CLR_ERR);
 	pci_mmio_writel(tmp, nicintel_spibar + FLA);
 	tmp = pci_mmio_readl(nicintel_spibar + FLA);
-	if (!tmp & (1 << FL_ABORT)) {
+	if (!(tmp & BIT(FL_ABORT))) {
 		msg_perr("Unable to clear Flash Access Error. Abort\n");
 		return 1;
 	}

--- a/nicintel_spi.c
+++ b/nicintel_spi.c
@@ -70,6 +70,9 @@
 #define FL_SO	3
 #define FL_REQ	4
 #define FL_GNT	5
+#define FL_LOCKED  6
+#define FL_ABORT   7
+#define FL_CLR_ERR 8
 /* Currently unused */
 // #define FL_BUSY	30
 // #define FL_ER	31
@@ -94,6 +97,14 @@ const struct dev_entry nics_intel_spi[] = {
 	{PCI_VENDOR_ID_INTEL, 0x1529, NT, "Intel", "82599 10 Gigabit Dual Port Network Controller with FCoE"},
 	{PCI_VENDOR_ID_INTEL, 0x152a, NT, "Intel", "82599 10 Gigabit Dual Port Backplane Controller with FCoE"},
 	{PCI_VENDOR_ID_INTEL, 0x1557, NT, "Intel", "82599 10 Gigabit SFI Network Controller"},
+
+	{PCI_VENDOR_ID_INTEL, 0x1531, OK, "Intel", "I210 Gigabit Network Connection Unprogrammed"},
+	{PCI_VENDOR_ID_INTEL, 0x1532, NT, "Intel", "I211 Gigabit Network Connection Unprogrammed"},
+	{PCI_VENDOR_ID_INTEL, 0x1533, NT, "Intel", "I210 Gigabit Network Connection"},
+	{PCI_VENDOR_ID_INTEL, 0x1536, NT, "Intel", "I210 Gigabit Network Connection SERDES Fiber"},
+	{PCI_VENDOR_ID_INTEL, 0x1537, NT, "Intel", "I210 Gigabit Network Connection SERDES Backplane"},
+	{PCI_VENDOR_ID_INTEL, 0x1538, NT, "Intel", "I210 Gigabit Network Connection SGMII"},
+	{PCI_VENDOR_ID_INTEL, 0x1539, NT, "Intel", "I211 Gigabit Network Connection"},
 
 	{0},
 };
@@ -182,31 +193,9 @@ static int nicintel_spi_shutdown(void *data)
 	return 0;
 }
 
-int nicintel_spi_init(void)
+static int nicintel_spi_82599_enable_flash(void)
 {
-	struct pci_dev *dev = NULL;
 	uint32_t tmp;
-
-	if (rget_io_perms())
-		return 1;
-
-	dev = pcidev_init(nics_intel_spi, PCI_BASE_ADDRESS_0);
-	if (!dev)
-		return 1;
-
-	uint32_t io_base_addr = pcidev_readbar(dev, PCI_BASE_ADDRESS_0);
-	if (!io_base_addr)
-		return 1;
-
-	if (dev->device_id < 0x10d8) {
-		nicintel_spibar = rphysmap("Intel Gigabit NIC w/ SPI flash", io_base_addr,
-					   MEMMAP_SIZE);
-	} else {
-		nicintel_spibar = rphysmap("Intel 10 Gigabit NIC w/ SPI flash", io_base_addr + 0x10000,
-					   MEMMAP_SIZE);
-	}
-	if (nicintel_spibar == ERROR_PTR)
-		return 1;
 
 	/* Automatic restore of EECD on shutdown is not possible because EECD
 	 * does not only contain FLASH_WRITES_DISABLED|FLASH_WRITES_ENABLED,
@@ -227,6 +216,65 @@ int nicintel_spi_init(void)
 
 	if (register_shutdown(nicintel_spi_shutdown, NULL))
 		return 1;
+
+	return 0;
+}
+
+static int nicintel_spi_i210_enable_flash()
+{
+	uint32_t tmp;
+
+	tmp = pci_mmio_readl(nicintel_spibar + FLA);
+	if (tmp & (1 << FL_LOCKED)) {
+		msg_perr("Flash is in Secure Mode. Abort.\n");
+		return 1;
+	}
+
+	if (!(tmp & (1 << FL_ABORT)))
+		return 0;
+
+	tmp |= (1 << FL_CLR_ERR);
+	pci_mmio_writel(tmp, nicintel_spibar + FLA);
+	tmp = pci_mmio_readl(nicintel_spibar + FLA);
+	if (!tmp & (1 << FL_ABORT)) {
+		msg_perr("Unable to clear Flash Access Error. Abort\n");
+		return 1;
+	}
+
+	return 0;
+}
+
+int nicintel_spi_init(void)
+{
+	struct pci_dev *dev = NULL;
+
+	if (rget_io_perms())
+		return 1;
+
+	dev = pcidev_init(nics_intel_spi, PCI_BASE_ADDRESS_0);
+	if (!dev)
+		return 1;
+
+	uint32_t io_base_addr = pcidev_readbar(dev, PCI_BASE_ADDRESS_0);
+	if (!io_base_addr)
+		return 1;
+
+	if ((dev->device_id & 0xfff0) == 0x1530) {
+		nicintel_spibar = rphysmap("Intel I210 Gigabit w/ SPI flash", io_base_addr + 0x12000,
+					   MEMMAP_SIZE);
+		if (!nicintel_spibar || nicintel_spi_i210_enable_flash())
+				return 1;
+	} else if (dev->device_id < 0x10d8) {
+		nicintel_spibar = rphysmap("Intel Gigabit NIC w/ SPI flash", io_base_addr,
+					   MEMMAP_SIZE);
+		if (!nicintel_spibar || nicintel_spi_82599_enable_flash())
+				return 1;
+	} else {
+		nicintel_spibar = rphysmap("Intel 10 Gigabit NIC w/ SPI flash", io_base_addr + 0x10000,
+					   MEMMAP_SIZE);
+		if (!nicintel_spibar || nicintel_spi_82599_enable_flash())
+				return 1;
+	}
 
 	if (register_spi_bitbang_master(&bitbang_spi_master_nicintel))
 		return 1;


### PR DESCRIPTION
Implements I210 "raw" flash access as detailed in:
http://www.intel.com/content/www/us/en/embedded/products/networking/i210-ethernet-controller-datasheet.html

Unfortunately, most of the time the card is in Secure Mode, which means
that the raw access is not available. But his should be pretty useful
for bringing up boards.

Signed-off-by: Ricardo Ribalda Delgado <ricardo.ribalda@gmail.com>