### PR TITLE
Add OTP area read function

### DIFF
--- a/chipdrivers.h
+++ b/chipdrivers.h
@@ -31,6 +31,7 @@
 int spi_aai_write(struct flashctx *flash, const uint8_t *buf, unsigned int start, unsigned int len);
 int spi_chip_write_256(struct flashctx *flash, const uint8_t *buf, unsigned int start, unsigned int len);
 int spi_chip_read(struct flashctx *flash, uint8_t *buf, unsigned int start, int unsigned len);
+int spi_chip_otp_read(struct flashctx *flash, uint8_t *buf);
 
 /* spi25.c */
 int probe_spi_rdid(struct flashctx *flash);

--- a/flash.h
+++ b/flash.h
@@ -162,6 +162,8 @@ struct flashchip {
 	unsigned int total_size;
 	/* Chip page size in bytes */
 	unsigned int page_size;
+	/* otp section size in bytes */
+	unsigned int otp_size;
 	int feature_bits;
 
 	/* Indicate how well flashrom supports different operations of this flash chip. */
@@ -200,6 +202,7 @@ struct flashchip {
 	int (*unlock) (struct flashctx *flash);
 	int (*write) (struct flashctx *flash, const uint8_t *buf, unsigned int start, unsigned int len);
 	int (*read) (struct flashctx *flash, uint8_t *buf, unsigned int start, unsigned int len);
+	int (*otp_read) (struct flashctx *flash, uint8_t *buf);
 	struct voltage {
 		uint16_t min;
 		uint16_t max;
@@ -292,6 +295,7 @@ int write_buf_to_file(const unsigned char *buf, unsigned long size, const char *
 int prepare_flash_access(struct flashctx *, bool read_it, bool write_it, bool erase_it, bool verify_it);
 void finalize_flash_access(struct flashctx *);
 int do_read(struct flashctx *, const char *filename);
+int do_otp_read(struct flashctx *, const char *filename);
 int do_erase(struct flashctx *);
 int do_write(struct flashctx *, const char *const filename);
 int do_verify(struct flashctx *, const char *const filename);

--- a/flashchips.c
+++ b/flashchips.c
@@ -42,6 +42,7 @@ const struct flashchip flashchips[] = {
 	 * .model_id		= Model chip ID
 	 * .total_size		= Total size in (binary) kbytes
 	 * .page_size		= Page or eraseblock(?) size in bytes
+	 * .otp_size		= OTP section size in bytes
 	 * .tested		= Test status
 	 * .probe		= Probe function
 	 * .probe_timing	= Probe function delay
@@ -54,6 +55,7 @@ const struct flashchip flashchips[] = {
 	 * .unlock		= Chip unlock function
 	 * .write		= Chip write function
 	 * .read		= Chip read function
+	 * .otp_read		= Chip OTP read function
 	 * .voltage		= Voltage range in millivolt
 	 */
 
@@ -7823,6 +7825,7 @@ const struct flashchip flashchips[] = {
 		.model_id	= MACRONIX_MX25L6405,
 		.total_size	= 8192,
 		.page_size	= 256,
+		.otp_size	= 64,
 		/* Has an additional 512B EEPROM sector */
 		.feature_bits	= FEATURE_WRSR_WREN,
 		.tested		= TEST_OK_PREW,
@@ -7848,6 +7851,7 @@ const struct flashchip flashchips[] = {
 		.unlock		= spi_disable_blockprotect_bp3_srwd,
 		.write		= spi_chip_write_256,
 		.read		= spi_chip_read, /* Fast read (0x0B) supported */
+		.otp_read	= spi_chip_otp_read,
 		.voltage	= {2700, 3600},
 	},
 
@@ -7859,6 +7863,7 @@ const struct flashchip flashchips[] = {
 		.model_id	= MACRONIX_MX25L6405,
 		.total_size	= 8192,
 		.page_size	= 256,
+		.otp_size	= 64,
 		/* OTP: 64B total; enter 0xB1, exit 0xC1 */
 		.feature_bits	= FEATURE_WRSR_WREN | FEATURE_OTP,
 		.tested		= TEST_OK_PREW,
@@ -7884,6 +7889,7 @@ const struct flashchip flashchips[] = {
 		.unlock		= spi_disable_blockprotect_bp3_srwd,
 		.write		= spi_chip_write_256,
 		.read		= spi_chip_read, /* Fast read (0x0B), dual I/O read (0xBB) supported */
+		.otp_read	= spi_chip_otp_read,
 		.voltage	= {2700, 3600},
 	},
 

--- a/flashrom.c
+++ b/flashrom.c
@@ -1438,6 +1438,37 @@ out_free:
 	return ret;
 }
 
+static int otp_read(struct flashctx *, uint8_t *);
+int otp_read_flash_to_file(struct flashctx *flash, const char *filename)
+{
+	unsigned long size = flash->chip->otp_size;
+	unsigned char *buf = calloc(size, sizeof(char));
+	int ret = 0;
+
+	msg_cinfo("Reading otp flash section... ");
+	if (!buf) {
+		msg_gerr("Memory allocation failed!\n");
+		msg_cinfo("FAILED.\n");
+		return 1;
+	}
+	if (!flash->chip->otp_read) {
+		msg_cerr("No otp read function available for this flash chip.\n");
+		ret = 1;
+		goto out_free;
+	}
+	if (otp_read(flash, buf)) {
+		msg_cerr("Otp read operation failed!\n");
+		ret = 1;
+		goto out_free;
+	}
+
+	ret = write_buf_to_file(buf, size, filename);
+out_free:
+	free(buf);
+	msg_cinfo("%s.\n", ret ? "FAILED" : "done");
+	return ret;
+}
+
 /* Even if an error is found, the function will keep going and check the rest. */
 static int selfcheck_eraseblocks(const struct flashchip *chip)
 {
@@ -1563,6 +1594,24 @@ static int read_by_layout(struct flashctx *const flashctx, uint8_t *const buffer
 		if (flashctx->chip->read(flashctx, buffer + region_start, region_start, region_len))
 			return 1;
 	}
+	return 0;
+}
+
+/**
+ * @brief Reads the OTP section into a buffer.
+ *
+ * @param flashctx Flash context to be used.
+ * @param buffer   Buffer of full chip size to read into.
+ * @return 0 on success,
+ *	   1 if any read fails.
+ */
+static int otp_read(struct flashctx *const flashctx, uint8_t *const buffer)
+{
+	//const struct flashrom_layout *const layout = get_layout(flashctx);
+
+	if (flashctx->chip->otp_read(flashctx, buffer))
+		return 1;
+
 	return 0;
 }
 
@@ -2503,6 +2552,18 @@ int do_read(struct flashctx *const flash, const char *const filename)
 		return 1;
 
 	const int ret = read_flash_to_file(flash, filename);
+
+	finalize_flash_access(flash);
+
+	return ret;
+}
+
+int do_otp_read(struct flashctx *const flash, const char *const filename)
+{
+	if (prepare_flash_access(flash, true, false, false, false))
+		return 1;
+
+	const int ret = otp_read_flash_to_file(flash, filename);
 
 	finalize_flash_access(flash);
 

--- a/spi.c
+++ b/spi.c
@@ -127,6 +127,30 @@ int spi_chip_read(struct flashctx *flash, uint8_t *buf, unsigned int start,
 	return flash->mst->spi.read(flash, buf, addrbase + start, len);
 }
 
+
+int spi_chip_otp_read(struct flashctx *flash, uint8_t *buf)
+{
+        static const unsigned char otp_incmd[JEDEC_ENSO_OUTSIZE] = { JEDEC_ENSO };
+        static const unsigned char otp_outcmd[JEDEC_EXSO_OUTSIZE] = { JEDEC_EXSO };
+        int ret;
+
+	ret = spi_send_command(flash, sizeof(otp_incmd), 0, otp_incmd, NULL);
+	if (!ret)
+		ret = flash->mst->spi.read(flash, buf, 0, flash->chip->otp_size);
+	else
+		msg_perr("Error on sending ENSO cmd.\n");
+
+	if (!ret)
+		ret += spi_send_command(flash, sizeof(otp_outcmd), 0, otp_outcmd, NULL);
+	else
+		msg_perr("Error on reading OTP data.\n");
+
+	if (ret)
+		msg_perr("Error on sendinf EXSO cmd.\n");
+
+	return ret;
+}
+
 /*
  * Program chip using page (256 bytes) programming.
  * Some SPI masters can't do this, they use single byte programming instead.

--- a/spi.h
+++ b/spi.h
@@ -141,6 +141,16 @@
 #define JEDEC_READ_OUTSIZE	0x04
 /*      JEDEC_READ_INSIZE : any length */
 
+/* Enter secured OTP */
+#define JEDEC_ENSO		0xB1
+#define JEDEC_ENSO_OUTSIZE	0x01
+#define JEDEC_ENSO_INSIZE	0x00
+
+/* Exit secured OTP */
+#define JEDEC_EXSO		0xC1
+#define JEDEC_EXSO_OUTSIZE	0x01
+#define JEDEC_EXSO_INSIZE	0x00
+
 /* Write memory byte */
 #define JEDEC_BYTE_PROGRAM		0x02
 #define JEDEC_BYTE_PROGRAM_OUTSIZE	0x05


### PR DESCRIPTION
The support to read the flash's OTP area has been added.
The implementation is limited to the MX25L6405 device.
Fully tested on that device.

Change-Id: Iad8fa1cace1af8e02824ee1a8a2d1d4425b55378
Signed-off-by: Giuseppe Lippolis <giu.lippolis@gmail.com>