### PR TITLE
do not stop probing for flashchips after map_flash() failed

### DIFF
--- a/flashrom.c
+++ b/flashrom.c
@@ -1224,7 +1224,7 @@ int probe_flash(struct registered_master *mst, int startchip, struct flashctx *f
 		flash->mst = mst;
 
 		if (map_flash(flash) != 0)
-			return -1;
+			goto notfound;
 
 		/* We handle a forced match like a real match, we just avoid probing. Note that probe_flash()
 		 * is only called with force=1 after normal probing failed.


### PR DESCRIPTION
Instead, continue probing the next chip.

This fixes the problem that flashrom aborts probing for
flashchips if one big flashchip (e.g. 32M/64M) can't be mapped
because of activated CONFIG_STRICT_DEVMEM kernel option.

Signed-off-by: Martin Schiller <ms@dev.tdt.de>