### PR TITLE
buspirate_spi: when using pullup=on, you do not want 3v3 on the IOs, …

### DIFF
--- a/buspirate_spi.c
+++ b/buspirate_spi.c
@@ -436,6 +436,10 @@ int buspirate_spi_init(void)
 	
 	/* Set SPI config: output type, idle, clock edge, sample */
 	bp_commbuf[0] = 0x80 | 0xa;
+	if (pullup == 1) {
+		bp_commbuf[0] &= ~(1 << 3);
+		msg_pdbg("Pull-ups enabled, so using HiZ pin output! (Open-Drain mode)\n");
+	}
 	ret = buspirate_sendrecv(bp_commbuf, 1, 1);
 	if (ret)
 		return 1;


### PR DESCRIPTION
…but rather use them open-drain

-> Currently, flashrom will fry e.g. 1v8 chips when using the pullups=on mode, since there is still 3v3 applied on the SPI pins. This patches fixes that. 

Change-Id: I9ac4c6b7a0079bb1022f2d70030a6eb29996108f