### PR TITLE
Fix mingw detection on Windows 7 (NT-6.1)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,14 +97,11 @@ debug_shell = $(shell export LC_ALL=C ; { echo 'exec: export LC_ALL=C ; { $(1) ;
 
 # HOST_OS is only used to work around local toolchain issues.
 HOST_OS ?= $(shell uname)
-
-# Use a regexp to check if we are building in a mingw enviroment.
-# uname returns MINGW32_NT-5.1 on XP, MINGW32_NT-6.1 on Windows 7
-# the regexp should support 64 bit variant of mingw if exists
-ifeq ($(shell if  [[ $$(uname) =~ ^MINGW[0-9]{0,2}_NT-[0-9]{1,2}.[0-9]{1,2}$$ ]]; then echo yes; else echo no; fi), yes)
+ifeq ($(findstring MINGW, $(HOST_OS)), MINGW)
 # Explicitly set CC = gcc on MinGW, otherwise: "cc: command not found".
 CC = gcc
 endif
+
 ifneq ($(HOST_OS), SunOS)
 STRIP_ARGS = -s
 endif

--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,11 @@ debug_shell = $(shell export LC_ALL=C ; { echo 'exec: export LC_ALL=C ; { $(1) ;
 
 # HOST_OS is only used to work around local toolchain issues.
 HOST_OS ?= $(shell uname)
-ifeq ($(HOST_OS), MINGW32_NT-5.1)
+
+# Use a regexp to check if we are building in a mingw enviroment.
+# uname returns MINGW32_NT-5.1 on XP, MINGW32_NT-6.1 on Windows 7
+# the regexp should support 64 bit variant of mingw if exists
+ifeq ($(shell if  [[ $$(uname) =~ ^MINGW[0-9]{0,2}_NT-[0-9]{1,2}.[0-9]{1,2}$$ ]]; then echo yes; else echo no; fi), yes)
 # Explicitly set CC = gcc on MinGW, otherwise: "cc: command not found".
 CC = gcc
 endif

--- a/util/ich_descriptors_tool/Makefile
+++ b/util/ich_descriptors_tool/Makefile
@@ -31,7 +31,12 @@ EXEC_SUFFIX := .exe
 CFLAGS += -Wno-format
 endif
 
-ifeq ($(TARGET_OS), MinGW)
+# Use a regexp to check if we are building in a mingw enviroment.
+# uname returns MINGW32_NT-5.1 on XP, MINGW32_NT-6.1 on Windows 7
+# the regexp should support 64 bit variant of mingw if exists
+ifeq ($(shell if  [[ $$(uname) =~ ^MINGW[0-9]{0,2}_NT-[0-9]{1,2}.[0-9]{1,2}$$ ]]; then echo yes; else echo no; fi), yes)
+# Explicitly set CC = gcc on MinGW, otherwise: "cc: command not found".
+CC = gcc
 EXEC_SUFFIX := .exe
 # Some functions provided by Microsoft do not work as described in C99 specifications. This macro fixes that
 # for MinGW. See http://sourceforge.net/p/mingw-w64/wiki2/printf%20and%20scanf%20family/ */

--- a/util/ich_descriptors_tool/Makefile
+++ b/util/ich_descriptors_tool/Makefile
@@ -31,10 +31,7 @@ EXEC_SUFFIX := .exe
 CFLAGS += -Wno-format
 endif
 
-# Use a regexp to check if we are building in a mingw enviroment.
-# uname returns MINGW32_NT-5.1 on XP, MINGW32_NT-6.1 on Windows 7
-# the regexp should support 64 bit variant of mingw if exists
-ifeq ($(shell if  [[ $$(uname) =~ ^MINGW[0-9]{0,2}_NT-[0-9]{1,2}.[0-9]{1,2}$$ ]]; then echo yes; else echo no; fi), yes)
+ifeq ($(findstring MINGW, $(HOST_OS)), MINGW)
 # Explicitly set CC = gcc on MinGW, otherwise: "cc: command not found".
 CC = gcc
 EXEC_SUFFIX := .exe

--- a/util/ich_descriptors_tool/Makefile
+++ b/util/ich_descriptors_tool/Makefile
@@ -22,15 +22,7 @@ CC ?= gcc
 # completely ignored by gnumake.
 CFLAGS ?= -Os -Wall -Wshadow
 
-override TARGET_OS := $(shell $(CC) $(CPPFLAGS) -E $(SHAREDSRCDIR)/os.h | grep -v '^\#' | grep '"' | \
-			cut -f 2 -d'"')
-
-ifeq ($(TARGET_OS), DOS)
-EXEC_SUFFIX := .exe
-# DJGPP has odd uint*_t definitions which cause lots of format string warnings.
-CFLAGS += -Wno-format
-endif
-
+HOST_OS ?= $(shell uname)
 ifeq ($(findstring MINGW, $(HOST_OS)), MINGW)
 # Explicitly set CC = gcc on MinGW, otherwise: "cc: command not found".
 CC = gcc
@@ -38,6 +30,15 @@ EXEC_SUFFIX := .exe
 # Some functions provided by Microsoft do not work as described in C99 specifications. This macro fixes that
 # for MinGW. See http://sourceforge.net/p/mingw-w64/wiki2/printf%20and%20scanf%20family/ */
 FLASHROM_CFLAGS += -D__USE_MINGW_ANSI_STDIO=1
+endif
+
+override TARGET_OS := $(shell $(CC) $(CPPFLAGS) -E $(SHAREDSRCDIR)/os.h | grep -v '^\#' | grep '"' | \
+			cut -f 2 -d'"')
+
+ifeq ($(TARGET_OS), DOS)
+EXEC_SUFFIX := .exe
+# DJGPP has odd uint*_t definitions which cause lots of format string warnings.
+CFLAGS += -Wno-format
 endif
 
 ifeq ($(WARNERROR), yes)


### PR DESCRIPTION
On Windows 7 the uname command returns witn MING32_NT-6.1 so the CC quirk of the Makefile does not get applied. 

This PR replaces the comparison of the uname with the "MINGW32_NT-5.1" with a regular expression which should properly detect the mingw on newer windows variants (8,8.1,10). I am not aware of 64 bit mingw builds yet, but the regexp will cover if it will be available in the future. 