### PR TITLE
added support for atmel AT25XE041B

### DIFF
--- a/flashchips.c
+++ b/flashchips.c
@@ -2177,6 +2177,35 @@ const struct flashchip flashchips[] = {
 
 	{
 		.vendor		= "Atmel",
+		.name		= "AT25XE041B",
+		.bustype	= BUS_SPI,
+		.manufacture_id	= ATMEL_ID,
+		.model_id	= ATMEL_AT25XE041B,
+		.total_size	= 512,
+		.page_size	= 256,
+		.feature_bits	= FEATURE_WRSR_WREN,
+		.tested		= TEST_OK_PREW,
+		.probe		= probe_spi_rdid,
+		.probe_timing	= TIMING_ZERO,
+		.block_erasers	=
+		{
+			{
+				.eraseblocks = { {64 * 1024, 8} },
+				.block_erase = spi_block_erase_d8,
+			}, {
+				.eraseblocks = { {512 * 1024, 1} },
+				.block_erase = spi_block_erase_c7,
+			}
+		},
+		.printlock	= spi_prettyprint_status_register_at25df,
+		.unlock		= spi_disable_blockprotect_at2x_global_unprotect,
+		.write		= spi_chip_write_256,
+		.read		= spi_chip_read,
+		.voltage	= {1600, 3600}, /* 1.6V - 3.6V */
+	},
+
+	{
+		.vendor		= "Atmel",
 		.name		= "AT26DF041",
 		.bustype	= BUS_SPI,
 		.manufacture_id	= ATMEL_ID,

--- a/flashchips.h
+++ b/flashchips.h
@@ -150,6 +150,7 @@
 #define ATMEL_AT25F4096		0x64	/* Needs AT25F_RDID */
 #define ATMEL_AT25FS010		0x6601
 #define ATMEL_AT25FS040		0x6604
+#define ATMEL_AT25XE041B	0x4402
 #define ATMEL_AT26DF041		0x4400
 #define ATMEL_AT26DF081		0x4500	/* guessed, no datasheet available */
 #define ATMEL_AT26DF081A	0x4501


### PR DESCRIPTION
Change-Id: Ia3618a69d9cc409ced3d49095afea4ae7ad8880a

according to datasheet https://www.adestotech.com/wp-content/uploads/DS-AT25XE041B_062.pdf, tested in production