### PR TITLE
Change libsub0 to libusb

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ debug_shell = $(shell export LC_ALL=C ; { echo 'exec: export LC_ALL=C ; { $(1) ;
 
 # HOST_OS is only used to work around local toolchain issues.
 HOST_OS ?= $(shell uname)
-ifeq ($(HOST_OS), MINGW32_NT-5.1)
+ifeq ($(findstring MINGW, $(HOST_OS)), MINGW)
 # Explicitly set CC = gcc on MinGW, otherwise: "cc: command not found".
 CC = gcc
 endif
@@ -189,7 +189,7 @@ endif
 ifeq ($(TARGET_OS), MinGW)
 EXEC_SUFFIX := .exe
 # MinGW doesn't have the ffs() function, but we can use gcc's __builtin_ffs().
-FLASHROM_CFLAGS += -Dffs=__builtin_ffs
+FLASHROM_CFLAGS += -Dffs=__builtin_ffs -D_CRT_SECURE_NO_WARNINGS
 # Some functions provided by Microsoft do not work as described in C99 specifications. This macro fixes that
 # for MinGW. See http://sourceforge.net/p/mingw-w64/wiki2/printf%20and%20scanf%20family/ */
 FLASHROM_CFLAGS += -D__USE_MINGW_ANSI_STDIO=1
@@ -658,10 +658,8 @@ $(foreach var, $(filter CONFIG_%, $(.VARIABLES)),\
 endif
 
 # Disable feature groups
-ifeq ($(CONFIG_ENABLE_LIBUSB0_PROGRAMMERS), no)
-override CONFIG_PICKIT2_SPI = no
-endif
 ifeq ($(CONFIG_ENABLE_LIBUSB1_PROGRAMMERS), no)
+override CONFIG_PICKIT2_SPI = no
 override CONFIG_CH341A_SPI = no
 override CONFIG_DEDIPROG = no
 endif
@@ -828,7 +826,7 @@ endif
 ifeq ($(CONFIG_PICKIT2_SPI), yes)
 FEATURE_CFLAGS += -D'CONFIG_PICKIT2_SPI=1'
 PROGRAMMER_OBJS += pickit2_spi.o
-NEED_LIBUSB0 += CONFIG_PICKIT2_SPI
+NEED_LIBUSB1 += CONFIG_PICKIT2_SPI
 endif
 
 ifneq ($(NEED_LIBFTDI), )
@@ -975,11 +973,6 @@ endif
 
 endif
 
-ifneq ($(NEED_LIBUSB0), )
-CHECK_LIBUSB0 = yes
-FEATURE_CFLAGS += -D'NEED_LIBUSB0=1'
-USBLIBS := $(call debug_shell,[ -n "$(PKG_CONFIG_LIBDIR)" ] && export PKG_CONFIG_LIBDIR="$(PKG_CONFIG_LIBDIR)" ; $(PKG_CONFIG) --libs libusb || printf "%s" "-lusb")
-endif
 
 ifneq ($(NEED_LIBUSB1), )
 CHECK_LIBUSB1 = yes
@@ -1020,7 +1013,7 @@ ifeq ($(ARCH), x86)
 endif
 
 $(PROGRAM)$(EXEC_SUFFIX): $(OBJS)
-	$(CC) $(LDFLAGS) -o $(PROGRAM)$(EXEC_SUFFIX) $(OBJS) $(LIBS) $(PCILIBS) $(FEATURE_LIBS) $(USBLIBS) $(USB1LIBS)
+	$(CC) -o $(PROGRAM)$(EXEC_SUFFIX) $(OBJS) $(LIBS) $(PCILIBS) $(FEATURE_LIBS) $(USBLIBS) $(USB1LIBS)  $(LDFLAGS)
 
 libflashrom.a: $(LIBFLASHROM_OBJS)
 	$(AR) rcs $@ $^
@@ -1124,23 +1117,6 @@ int main(int argc, char **argv)
 endef
 export PCI_GET_DEV_TEST
 
-define LIBUSB0_TEST
-#include "platform.h"
-#if IS_WINDOWS
-#include <lusb0_usb.h>
-#else
-#include <usb.h>
-#endif
-int main(int argc, char **argv)
-{
-	(void) argc;
-	(void) argv;
-	usb_init();
-	return 0;
-}
-endef
-export LIBUSB0_TEST
-
 define LIBUSB1_TEST
 #include <stddef.h>
 #include <libusb.h>
@@ -1186,28 +1162,6 @@ ifeq ($(CHECK_LIBPCI), yes)
 		echo "mentioned above by specifying make CONFIG_ENABLE_LIBPCI_PROGRAMMERS=no"; \
 		echo "See README for more information."; echo;				\
 		rm -f .test.c .test.o .test$(EXEC_SUFFIX); exit 1; }; }; } 2>>$(BUILD_DETAILS_FILE); echo $? >&3 ; } | tee -a $(BUILD_DETAILS_FILE) >&4; } 3>&1;} | { read rc ; exit ${rc}; } } 4>&1
-	@rm -f .test.c .test.o .test$(EXEC_SUFFIX)
-endif
-ifeq ($(CHECK_LIBUSB0), yes)
-	@printf "Checking for libusb-0.1/libusb-compat headers... " | tee -a $(BUILD_DETAILS_FILE)
-	@echo "$$LIBUSB0_TEST" > .test.c
-	@printf "\nexec: %s\n" "$(CC) -c $(CPPFLAGS) $(CFLAGS) .test.c -o .test.o" >>$(BUILD_DETAILS_FILE)
-	@{ { { { { $(CC) -c $(CPPFLAGS) $(CFLAGS) .test.c -o .test.o >&2 && \
-		echo "found." || { echo "not found."; echo;				\
-		echo "The following features require libusb-0.1/libusb-compat: $(NEED_LIBUSB0)."; \
-		echo "Please install libusb-0.1 headers or libusb-compat headers or disable all features"; \
-		echo "mentioned above by specifying make CONFIG_ENABLE_LIBUSB0_PROGRAMMERS=no"; \
-		echo "See README for more information."; echo;				\
-		rm -f .test.c .test.o; exit 1; }; } 2>>$(BUILD_DETAILS_FILE); echo $? >&3 ; } | tee -a $(BUILD_DETAILS_FILE) >&4; } 3>&1;} | { read rc ; exit ${rc}; } } 4>&1
-	@printf "Checking if libusb-0.1 is usable... " | tee -a $(BUILD_DETAILS_FILE)
-	@printf "\nexec: %s\n" "$(CC) $(LDFLAGS) .test.o -o .test$(EXEC_SUFFIX) $(LIBS) $(USBLIBS)" >>$(BUILD_DETAILS_FILE)
-	@{ { { { { $(CC) $(LDFLAGS) .test.o -o .test$(EXEC_SUFFIX) $(LIBS) $(USBLIBS) >&2 && \
-		echo "yes." || { echo "no.";						\
-		echo "The following features require libusb-0.1/libusb-compat: $(NEED_LIBUSB0)."; \
-		echo "Please install libusb-0.1 or libusb-compat or disable all features"; \
-		echo "mentioned above by specifying make CONFIG_ENABLE_LIBUSB0_PROGRAMMERS=no"; \
-		echo "See README for more information."; echo;				\
-		rm -f .test.c .test.o .test$(EXEC_SUFFIX); exit 1; }; } 2>>$(BUILD_DETAILS_FILE); echo $? >&3 ; } | tee -a $(BUILD_DETAILS_FILE) >&4; } 3>&1;} | { read rc ; exit ${rc}; } } 4>&1
 	@rm -f .test.c .test.o .test$(EXEC_SUFFIX)
 endif
 ifeq ($(CHECK_LIBUSB1), yes)

--- a/pickit2_spi.c
+++ b/pickit2_spi.c
@@ -3,6 +3,7 @@
  *
  * Copyright (C) 2010 Carl-Daniel Hailfinger
  * Copyright (C) 2014 Justin Chevrier
+ * Copyright (C) 2017 Tomislav Gotic
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -44,11 +45,7 @@
 #include <limits.h>
 #include <errno.h>
 
-#if IS_WINDOWS
-#include <lusb0_usb.h>
-#else
-#include <usb.h>
-#endif
+#include <libusb.h>
 
 #include "flash.h"
 #include "chipdrivers.h"
@@ -60,105 +57,212 @@ const struct dev_entry devs_pickit2_spi[] = {
 
 	{}
 };
-
-static usb_dev_handle *pickit2_handle;
+struct libusb_context *usb_ctx;
+static libusb_device_handle *pickit2_handle;
 
 /* Default USB transaction timeout in ms */
-#define DFLT_TIMEOUT            10000
+#define DFLT_TIMEOUT			1000U
+#define MB1						1048576U
+#define KB8						8192U
+#define PICKIT2_SCLK_MAX_kHz	1000U
+#define PICKIT2_Vdd_MIN_mV		2500
+#define PICKIT2_Vdd_MAX_mV		5000
+#define PICKIT2_ERR_MASK_LO		0x30
+#define PICKIT2_ERR_MASK_HI		0xFC
 
-#define CMD_LENGTH              64
-#define ENDPOINT_OUT            0x01
-#define ENDPOINT_IN             0x81
+#define ENDPOINT_OUT			0x01
+#define ENDPOINT_IN				0x81
+#define USB_PACKET_LENGTH		64U		
 
-#define CMD_GET_VERSION         0x76
-#define CMD_SET_VDD             0xA0
-#define CMD_SET_VPP             0xA1
-#define CMD_READ_VDD_VPP        0xA3
-#define CMD_EXEC_SCRIPT         0xA6
-#define CMD_CLR_DLOAD_BUFF      0xA7
-#define CMD_DOWNLOAD_DATA       0xA8
-#define CMD_CLR_ULOAD_BUFF      0xA9
-#define CMD_UPLOAD_DATA         0xAA
-#define CMD_END_OF_BUFFER       0xAD
+#define CMD_FIRMWARE_VERSION	0x76
+#define CMD_SET_VDD				0xA0
+#define CMD_SET_VPP				0xA1
+#define CMD_READ_STATUS			0xA2
+#define CMD_READ_VDD_VPP		0xA3
+#define CMD_DOWNLOAD_SCRIPT		0xA4
+#define CMD_RUN_SCRIPT			0xA5
+#define CMD_EXEC_SCRIPT			0xA6
+#define CMD_CLR_DOWNLOAD_BUFFER	0xA7
+#define CMD_DOWNLOAD_DATA		0xA8
+#define CMD_CLR_UPLOAD_BUFFER	0xA9
+#define CMD_UPLOAD_DATA			0xAA
+#define CMD_CLR_SCRIPT_BUFFER	0xAB
+#define CMD_UPLOAD_DATA_NO_LEN	0xAC
+#define CMD_END_OF_BUFFER		0xAD
 
-#define SCR_SPI_READ_BUF        0xC5
-#define SCR_SPI_WRITE_BUF       0xC6
-#define SCR_SET_AUX             0xCF
-#define SCR_LOOP                0xE9
-#define SCR_SET_ICSP_CLK_PERIOD 0xEA
-#define SCR_SET_PINS            0xF3
-#define SCR_BUSY_LED_OFF        0xF4
-#define SCR_BUSY_LED_ON         0xF5
-#define SCR_MCLR_GND_OFF        0xF6
-#define SCR_MCLR_GND_ON         0xF7
-#define SCR_VPP_PWM_OFF         0xF8
-#define SCR_VPP_PWM_ON          0xF9
-#define SCR_VPP_OFF             0xFA
-#define SCR_VPP_ON              0xFB
-#define SCR_VDD_OFF             0xFE
-#define SCR_VDD_ON              0xFF
+#define SCR_SPI_READ_BUFFER		0xC5
+#define SCR_SPI_WRITE_BUFFER	0xC6
+#define	SCR_SPI_WRITE_LIT		0xC7
+#define SCR_SET_AUX				0xCF
+#define SCR_DELAY_LONG			0xE8
+#define SCR_LOOP				0xE9
+#define SCR_SET_ICSP_CLK_PERIOD	0xEA
+#define SCR_SET_PINS			0xF3
+#define SCR_BUSY_LED_OFF		0xF4
+#define SCR_BUSY_LED_ON			0xF5
+#define SCR_MCLR_GND_Q_OFF		0xF6
+#define SCR_MCLR_GND_Q_ON		0xF7
+#define SCR_VPP_PWM_OFF			0xF8
+#define SCR_VPP_PWM_ON			0xF9
+#define SCR_VPP_Q_OFF			0xFA
+#define SCR_VPP_Q_ON			0xFB
+#define SCR_VDD_OFF				0xFE
+#define SCR_VDD_ON				0xFF
+
+#define RUN_SCR_SPI_CS_HI		1U
+#define RUN_SCR_SPI_WRITE		2U
+#define RUN_SCR_SPI_READ		3U
+#define RUN_SCR_SPI_STATUS_REG	4U
+#define RUN_SCR_LED_ON			5U
 
 /* Might be useful for other USB devices as well. static for now.
  * device parameter allows user to specify one device of multiple installed */
-static struct usb_device *get_device_by_vid_pid(uint16_t vid, uint16_t pid, unsigned int device)
+static struct libusb_device_handle *get_device_by_vid_pid_number(uint16_t vid, uint16_t pid, unsigned int num)
 {
-	struct usb_bus *bus;
-	struct usb_device *dev;
+	struct libusb_device **list;
+	ssize_t count = libusb_get_device_list(usb_ctx, &list);
+	if (count < 0) {
+		msg_perr("Getting the USB device list failed (%s)!\n", libusb_error_name(count));
+		return NULL;
+	}
 
-	for (bus = usb_get_busses(); bus; bus = bus->next)
-		for (dev = bus->devices; dev; dev = dev->next)
-			if ((dev->descriptor.idVendor == vid) &&
-			    (dev->descriptor.idProduct == pid)) {
-				if (device == 0)
-					return dev;
-				device--;
+	struct libusb_device_handle *handle = NULL;
+	ssize_t i = 0;
+	for (i = 0; i < count; i++) {
+		struct libusb_device *dev = list[i];
+		struct libusb_device_descriptor desc;
+		int err = libusb_get_device_descriptor(dev, &desc);
+		if (err != 0) {
+			msg_perr("Reading the USB device descriptor failed (%s)!\n", libusb_error_name(err));
+			libusb_free_device_list(list, 1);
+			return NULL;
+		}
+		if ((desc.idVendor == vid) && (desc.idProduct == pid)) {
+		  int bus = libusb_get_bus_number(dev);
+		  int addr = libusb_get_device_address(dev);
+			msg_pinfo("Found USB device %04"PRIx16":%04"PRIx16" at address %d-%d.\n",
+				 desc.idVendor, desc.idProduct,
+				 bus, addr);
+			if (num == 0) {
+				err = libusb_open(dev, &handle);
+				if (err != 0) {
+					msg_perr("Opening the USB device failed (%s)!\n",
+						 libusb_error_name(err));
+					libusb_free_device_list(list, 1);
+					return NULL;
+				}
+				break;
 			}
+			num--;
+		}
+	}
+	libusb_free_device_list(list, 1);
 
-	return NULL;
+	return handle;
 }
 
 static int pickit2_get_firmware_version(void)
 {
-	int ret;
-	uint8_t command[CMD_LENGTH] = {CMD_GET_VERSION, CMD_END_OF_BUFFER};
+	int ret, transferred = 0;
+	uint8_t command[USB_PACKET_LENGTH] = {CMD_FIRMWARE_VERSION, CMD_END_OF_BUFFER};
 
-	ret = usb_interrupt_write(pickit2_handle, ENDPOINT_OUT, (char *)command, CMD_LENGTH, DFLT_TIMEOUT);
-	ret = usb_interrupt_read(pickit2_handle, ENDPOINT_IN, (char *)command, CMD_LENGTH, DFLT_TIMEOUT);
-	
-	msg_pdbg("PICkit2 Firmware Version: %d.%d\n", (int)command[0], (int)command[1]);
-	if (ret != CMD_LENGTH) {
-		msg_perr("Command Get Firmware Version failed (%s)!\n", usb_strerror());
-		return 1;
+	ret = libusb_interrupt_transfer(pickit2_handle, ENDPOINT_OUT, command, USB_PACKET_LENGTH, &transferred, DFLT_TIMEOUT);
+	if (ret == 0) {
+		ret = libusb_interrupt_transfer(pickit2_handle, ENDPOINT_IN, command, USB_PACKET_LENGTH, &transferred, DFLT_TIMEOUT);
+		if (ret == 0) {
+			msg_pinfo("PICkit2 Firmware Version: %"PRIu8".%"PRIu8".%"PRIu8"\n", command[0], command[1], command[2]);
+			return 0;
+		}
 	}
+	msg_perr("PicKit2 Get Firmware Version Command failed (%s)!\n", libusb_error_name(ret));
+	return SPI_PROGRAMMER_ERROR;
+}
 
-	return 0;
+static int pickit2_get_status()
+{
+	int ret, transferred = 0;
+	uint8_t command[USB_PACKET_LENGTH] = {CMD_READ_STATUS, CMD_END_OF_BUFFER};
+
+	ret = libusb_interrupt_transfer(pickit2_handle, ENDPOINT_OUT, command, USB_PACKET_LENGTH, &transferred, DFLT_TIMEOUT);
+	if (ret == 0) {
+		ret = libusb_interrupt_transfer(pickit2_handle, ENDPOINT_IN, command, USB_PACKET_LENGTH, &transferred, DFLT_TIMEOUT);
+		if (ret == 0) {
+			msg_pinfo("PICkit2 status(0x%"PRIx8" 0x%"PRIx8"):", command[0], command[1]);
+			if (command[0] & 0x40)
+				msg_pinfo("BTN,");
+			if (command[0] & 0x20)
+				msg_perr("VPP ERR,");
+			if (command[0] & 0x10)
+				msg_perr("VDD ERR,");
+			if (command[0] & 0x08)
+				msg_pinfo("/CS Hi,");
+			if (command[0] & 0x04)
+				msg_pinfo("/CS Low");
+			if (command[0] & 0x02)
+				msg_pinfo("VDD OFF,");
+			if (command[0] & 0x01)
+				msg_pinfo("VDD GND,");
+			if (command[1] & 0x80)
+				msg_perr("DL FULL ERR,");
+			if (command[1] & 0x40)
+				msg_perr("SCR ERR,");
+			if (command[1] & 0x20)
+				msg_perr("SCR EMPTY ERR,");
+			if (command[1] & 0x10)
+				msg_perr("SCR DL EMPTY ERR,");
+			if (command[1] & 0x08)
+				msg_perr("SCR UL FULL ERR,");
+			if (command[1] & 0x04)
+				msg_perr("ICD TOUT ERR");
+			if (command[1] & 0x02)
+				msg_pinfo("UART On,");
+			if (command[1] & 0x01)
+				msg_pinfo("RESET");
+			
+			msg_pinfo("\n");
+
+			return 0;
+		}
+	}
+	msg_perr("PicKit2 Read Status Command failed (%s)!\n", libusb_error_name(ret));
+	return SPI_PROGRAMMER_ERROR;
+}
+static int pickit2_check_errors()
+{
+	int ret, transferred = 0;
+	uint8_t command[USB_PACKET_LENGTH] = {
+		CMD_READ_STATUS,
+		CMD_RUN_SCRIPT,
+		RUN_SCR_LED_ON,
+		1,
+		CMD_END_OF_BUFFER
+	};
+
+	ret = libusb_interrupt_transfer(pickit2_handle, ENDPOINT_OUT, command, USB_PACKET_LENGTH, &transferred, DFLT_TIMEOUT);
+	if (ret == 0) {
+		ret = libusb_interrupt_transfer(pickit2_handle, ENDPOINT_IN, command, USB_PACKET_LENGTH, &transferred, DFLT_TIMEOUT);
+		if (ret == 0) {
+			if ((command[0] & PICKIT2_ERR_MASK_LO) || (command[1] & PICKIT2_ERR_MASK_HI)) {
+				msg_perr("PicKit Status Errors: 0x%"PRIx8" 0x%"PRIx8"!\n", (command[0] & PICKIT2_ERR_MASK_LO), (command[1] & PICKIT2_ERR_MASK_HI));
+				return SPI_PROGRAMMER_ERROR;
+			}
+			return 0;
+		}
+	}
+	msg_perr("PicKit2 Read Status Command failed (%s)!\n", libusb_error_name(ret));
+	return SPI_PROGRAMMER_ERROR;
 }
 
 static int pickit2_set_spi_voltage(int millivolt)
 {
-	double voltage_selector;
-	switch (millivolt) {
-	case 0:
-		/* Admittedly this one is an assumption. */
-		voltage_selector = 0;
-		break;
-	case 1800:
-		voltage_selector = 1.8;
-		break;
-	case 2500:
-		voltage_selector = 2.5;
-		break;
-	case 3500:
-		voltage_selector = 3.5;
-		break;
-	default:
-		msg_perr("Unknown voltage %i mV! Aborting.\n", millivolt);
-		return 1;
+	double voltage_selector = millivolt / 1000.0;
+	if ((millivolt < PICKIT2_Vdd_MIN_mV) || (millivolt > PICKIT2_Vdd_MAX_mV)) {
+		msg_perr("Cannot set Vdd to %.3fV! Aborting.\n", voltage_selector);
+		return SPI_PROGRAMMER_ERROR;
 	}
-	msg_pdbg("Setting SPI voltage to %u.%03u V\n", millivolt / 1000,
-		 millivolt % 1000);
+	msg_pdbg("Setting Vdd voltage to %.3f V\n", voltage_selector);
 
-	uint8_t command[CMD_LENGTH] = {
+	uint8_t command[USB_PACKET_LENGTH] = {
 		CMD_SET_VDD,
 		voltage_selector * 2048 + 672,
 		(voltage_selector * 2048 + 672) / 256,
@@ -169,138 +273,159 @@ static int pickit2_set_spi_voltage(int millivolt)
 		voltage_selector * 13,
 		CMD_END_OF_BUFFER
 	};
+	int transferred = 0;
 
-	int ret = usb_interrupt_write(pickit2_handle, ENDPOINT_OUT, (char *)command, CMD_LENGTH, DFLT_TIMEOUT);
+	int ret = libusb_interrupt_transfer(pickit2_handle, ENDPOINT_OUT, command, USB_PACKET_LENGTH, &transferred, DFLT_TIMEOUT);
 
-	if (ret != CMD_LENGTH) {
-		msg_perr("Command Set Voltage failed (%s)!\n", usb_strerror());
-		return 1;
+	if (ret != 0) {
+		msg_perr("PicKit2 Set SPI Vdd Command failed (%s)!\n", libusb_error_name(ret));
+		return SPI_PROGRAMMER_ERROR;
 	}
 
 	return 0;
 }
 
-struct pickit2_spispeeds {
-	const char *const name;
-	const int speed;
-};
-
-static const struct pickit2_spispeeds spispeeds[] = {
-	{ "1M",		0x1 },
-	{ "500k",	0x2 },
-	{ "333k",	0x3 },
-	{ "250k",	0x4 },
-	{ NULL,		0x0 },
-};
-
-static int pickit2_set_spi_speed(unsigned int spispeed_idx)
+static int pickit2_set_spi_speed(unsigned int spispeed)
 {
-	msg_pdbg("SPI speed is %sHz\n", spispeeds[spispeed_idx].name);
-
-	uint8_t command[CMD_LENGTH] = {
+	uint8_t command[USB_PACKET_LENGTH] = {
 		CMD_EXEC_SCRIPT,
 		2,
 		SCR_SET_ICSP_CLK_PERIOD,
-		spispeed_idx,
+		(uint8_t)(PICKIT2_SCLK_MAX_kHz / spispeed),
 		CMD_END_OF_BUFFER
 	};
-
-	int ret = usb_interrupt_write(pickit2_handle, ENDPOINT_OUT, (char *)command, CMD_LENGTH, DFLT_TIMEOUT);
-
-	if (ret != CMD_LENGTH) {
-		msg_perr("Command Set SPI Speed failed (%s)!\n", usb_strerror());
-		return 1;
+	int transferred = 0;
+	int ret = libusb_interrupt_transfer(pickit2_handle, ENDPOINT_OUT, command, USB_PACKET_LENGTH, &transferred, DFLT_TIMEOUT);
+	
+	if (ret != 0) {
+		msg_perr("PicKit2 Set SPI Speed Command failed (%s)!\n", libusb_error_name(ret));
+		return SPI_PROGRAMMER_ERROR;
 	}
-
+	msg_pdbg("SPI CLK frequency %0.3f kHz\n", (1.0f / (int)(PICKIT2_SCLK_MAX_kHz / spispeed)) * 1000.0f);
+	
 	return 0;
 }
 
-static int pickit2_spi_send_command(struct flashctx *flash, unsigned int writecnt, unsigned int readcnt,
-				     const unsigned char *writearr, unsigned char *readarr)
+static int pickit2_spi_send_command(struct flashctx __attribute__((unused))*flash, unsigned int writecnt, unsigned int readcnt,
+									const unsigned char *writearr, unsigned char *readarr)
 {
+	int ret, transferred = 0;
+	unsigned int i = 0, n, cnt8k = 0, cnt1M = 0;
+	uint8_t buf[USB_PACKET_LENGTH] = { 0 };
 
-	/* Maximum number of bytes per transaction (including command overhead) is 64. Lets play it safe
-	 * and always assume the worst case scenario of 20 bytes command overhead.
-	 */
-	if (writecnt + readcnt + 20 > CMD_LENGTH) {
-		msg_perr("\nTotal packetsize (%i) is greater than 64 supported, aborting.\n",
-			 writecnt + readcnt + 20);
-		return 1;
-	}
-
-	uint8_t buf[CMD_LENGTH] = {CMD_DOWNLOAD_DATA, writecnt};
-	int i = 2;
-	for (; i < writecnt + 2; i++) {
-		buf[i] = writearr[i - 2];
-	}
-
-	buf[i++] = CMD_CLR_ULOAD_BUFF;
-	buf[i++] = CMD_EXEC_SCRIPT;
-
-	/* Determine script length based on number of bytes to be read or written */
-	if (writecnt == 1 && readcnt == 1)
-		buf[i++] = 7;
-	else if (writecnt == 1 || readcnt == 1)
-		buf[i++] = 10;
-	else
-		buf[i++] = 13;
-		
-	/* Assert CS# */
-	buf[i++] = SCR_VPP_OFF;
-	buf[i++] = SCR_MCLR_GND_ON;
-
-	buf[i++] = SCR_SPI_WRITE_BUF;
-
+	/* Write Flash instruction and data to PicKit2's Download buffer (256B).
+	* Write Instruction (02b xx xx xx) and Flash data can be larger than download buffer.
+	* Instruction and data are sent in 64B USB packets and executed when received. 
+	* SCLK must be > 10kHz to avoid download buffer overflow.
+	* Each USB interrupt packet is sent in 1ms time slots.
+	* At 1MHz SCLK, USB transfer is slower than PicKit2 to chip transfer.
+	* Try to minimize number of USB transfers and maximize USB payload. 
+	*/
 	if (writecnt > 1) {
-		buf[i++] = SCR_LOOP;
-		buf[i++] = 1; /* Loop back one instruction */
-		buf[i++] = writecnt - 1; /* Number of times to loop */
-	}
+		do {
+			n = (writecnt > 52) ? 52 : writecnt; /* 256 / 5 + 1 */
+			buf[i++] = CMD_DOWNLOAD_DATA;
+			buf[i++] = n;
+			memcpy(buf + i, writearr, n);
+			i += n;
 
-	if (readcnt)
-		buf[i++] = SCR_SPI_READ_BUF;
+			buf[i++] = CMD_RUN_SCRIPT;
+			buf[i++] = RUN_SCR_SPI_WRITE;
+			buf[i++] = n; 	/* Number of times to run SPI_WRITE script */
 
-	if (readcnt > 1) {
-		buf[i++] = SCR_LOOP;
-		buf[i++] = 1; /* Loop back one instruction */
-		buf[i++] = readcnt - 1; /* Number of times to loop */
-	}
-
-	/* De-assert CS# */
-	buf[i++] = SCR_MCLR_GND_OFF;
-	buf[i++] = SCR_VPP_PWM_ON;
-	buf[i++] = SCR_VPP_ON;
-
-	buf[i++] = CMD_UPLOAD_DATA;
-	buf[i++] = CMD_END_OF_BUFFER;
-
-	int ret = usb_interrupt_write(pickit2_handle, ENDPOINT_OUT, (char *)buf, CMD_LENGTH, DFLT_TIMEOUT);
-
-	if (ret != CMD_LENGTH) {
-		msg_perr("Send SPI failed, expected %i, got %i %s!\n", writecnt, ret, usb_strerror());
-		return 1;
-	}
-
-	if (readcnt) {
-		ret = usb_interrupt_read(pickit2_handle, ENDPOINT_IN, (char *)buf, CMD_LENGTH, DFLT_TIMEOUT);
-
-		if (ret != CMD_LENGTH) {
-			msg_perr("Receive SPI failed, expected %i, got %i %s!\n", readcnt, ret, usb_strerror());
-			return 1;
+			/* 3 = CS# Hi, 4 = READ_DATA */
+			if ((writecnt > 52) || (USB_PACKET_LENGTH < i + 3 + (readcnt ? 4 : 0))) {
+				if (i < USB_PACKET_LENGTH)
+					buf[i] = CMD_END_OF_BUFFER;
+				
+				/* msg_pdbg2("pickit2_spi_send_command!w%u/%u!%ub\n", n, writecnt, i); */
+				ret = libusb_interrupt_transfer(pickit2_handle, ENDPOINT_OUT, buf, USB_PACKET_LENGTH, &transferred, DFLT_TIMEOUT);
+				if (ret != 0) {
+					msg_perr("PicKit2 Send Write Script failed, sent %d %s!\n", transferred, libusb_error_name(ret));
+					return SPI_PROGRAMMER_ERROR;
+				}
+				i = 0;
+			}
+			writecnt -= n;
+			writearr += n;
+		} while (writecnt);
+	} 
+	else if (writecnt == 1) {
+		/* while checking status register, don't change data in the DOWNLOAD buffer*/
+		if (writearr[0] == JEDEC_RDSR) {
+			buf[i++] = CMD_RUN_SCRIPT;
+			buf[i++] = RUN_SCR_SPI_STATUS_REG;
+			buf[i++] = 1;
 		}
-
-		/* First byte indicates number of bytes transferred from upload buffer */
-		if (buf[0] != readcnt) {
-			msg_perr("Unexpected number of bytes transferred, expected %i, got %i!\n",
-				 readcnt, ret);
-			return 1;
+		else {
+			buf[i++] = CMD_EXEC_SCRIPT;
+			buf[i++] = 4;
+			/* CS# Low */
+			buf[i++] = SCR_VPP_Q_OFF;
+			buf[i++] = SCR_MCLR_GND_Q_ON;
+			buf[i++] = SCR_SPI_WRITE_LIT;
+			buf[i++] = writearr[0];
 		}
-		
-		/* Actual data starts at byte number two */
-		memcpy(readarr, &buf[1], readcnt);
 	}
+	do 
+	{
+		if (readcnt) {
+			n = (readcnt > USB_PACKET_LENGTH) ? USB_PACKET_LENGTH : readcnt; /* max 64B in one packet */
+			buf[i++] = CMD_RUN_SCRIPT;
+			buf[i++] = RUN_SCR_SPI_READ;
+			buf[i++] = n;						/* Number of times to run SPI_READ script / bytes to read */
+			buf[i++] = CMD_UPLOAD_DATA_NO_LEN;	/* Fetch data from Upload Buffer */
+		}
+		/* last USB packet/no packets to read, set CS# Hi */
+		if (readcnt <= USB_PACKET_LENGTH) {
+			/* CS# High */
+			buf[i++] = CMD_RUN_SCRIPT;
+			buf[i++] = RUN_SCR_SPI_CS_HI;
+			buf[i++] = 1;
+		}
+		/* mark end of commands */			
+		if (i < USB_PACKET_LENGTH)
+			buf[i] = CMD_END_OF_BUFFER;
 
-	return 0;
+		//msg_pdbg2("pickit2_spi_send_command!w63!%ub\n", i);
+		/* send commands to PicKit2 and Flash */
+		ret = libusb_interrupt_transfer(pickit2_handle, ENDPOINT_OUT, buf, USB_PACKET_LENGTH, &transferred, DFLT_TIMEOUT);
+		if (ret != 0) {
+			msg_perr("PicKit2 Send Read Script failed, sent %d %s!\n", transferred, libusb_error_name(ret));
+			return SPI_PROGRAMMER_ERROR;
+		} 
+		i = 0;
+		if (readcnt) {
+			/* Get data from PicKit2 or from Flash */
+			ret = libusb_interrupt_transfer(pickit2_handle, ENDPOINT_IN, buf, USB_PACKET_LENGTH, &transferred, DFLT_TIMEOUT);
+			if (ret != 0) {
+				msg_perr("PicKit2 Read Data failed, expected %u, got %d %s!\n", n, transferred, libusb_error_name(ret));
+				return SPI_PROGRAMMER_ERROR;
+			}
+			if (USB_PACKET_LENGTH == transferred) {
+				memcpy(readarr, buf, n);
+				readcnt -= n;
+				readarr += n;
+				cnt8k += n;
+				cnt1M += n;
+			}
+			else {
+				msg_perr("PicKit2 Data error, expected %u/%u, got %d %s!\n", n, USB_PACKET_LENGTH, transferred, libusb_error_name(ret));
+				return SPI_INVALID_LENGTH;
+			}
+			if (cnt1M / MB1) {
+				msg_pdbg2("*\n");
+				cnt1M -= MB1;
+				cnt8k = cnt1M;
+			}
+			if (cnt8k / KB8) {
+				msg_pdbg2(".");
+				cnt8k -= KB8;
+			}
+		}
+	} while (readcnt);
+	
+	return pickit2_check_errors();
 }
 
 /* Copied from dediprog.c */
@@ -311,7 +436,7 @@ static int parse_voltage(char *voltage)
 	int i;
 	int millivolt = 0, fraction = 0;
 
-	if (!voltage || !strlen(voltage)) {
+	if (!(voltage && *voltage)) {
 		msg_perr("Empty voltage= specified.\n");
 		return -1;
 	}
@@ -343,7 +468,7 @@ static int parse_voltage(char *voltage)
 		millivolt *= 1000;
 		millivolt += fraction;
 	} else if (!strncmp(voltage, "mv", 2) ||
-		   !strncmp(voltage, "millivolt", 9)) {
+			!strncmp(voltage, "millivolt", 9)) {
 		/* No adjustment. fraction is discarded. */
 	} else {
 		/* Garbage at the end of the string. */
@@ -354,153 +479,235 @@ static int parse_voltage(char *voltage)
 }
 
 static const struct spi_master spi_master_pickit2 = {
-	.type		= SPI_CONTROLLER_PICKIT2,
-	.max_data_read	= 40,
-	.max_data_write	= 40,
-	.command	= pickit2_spi_send_command,
+	.type			= SPI_CONTROLLER_PICKIT2,
+	.max_data_read	= 0xFFFFFF, /* 16MB, read complete chip with one instruction */
+	.max_data_write	= 256, 
+	.command		= pickit2_spi_send_command,
 	.multicommand	= default_spi_send_multicommand,
-	.read		= default_spi_read,
-	.write_256	= default_spi_write_256,
-	.write_aai	= default_spi_write_aai,
+	.read			= default_spi_read,
+	.write_256		= default_spi_write_256,
+	.write_aai		= default_spi_write_aai,
 };
 
-static int pickit2_shutdown(void *data)
+static int pickit2_shutdown(void __attribute__((unused))*data)
 {
 	/* Set all pins to float and turn voltages off */
-	uint8_t command[CMD_LENGTH] = {
+	uint8_t command[USB_PACKET_LENGTH] = {
 		CMD_EXEC_SCRIPT,
 		8,
+		/* CS# float */
+		SCR_VPP_Q_OFF,
+		SCR_MCLR_GND_Q_OFF,
 		SCR_SET_PINS,
-		3, /* Bit-0=1(PDC In), Bit-1=1(PGD In), Bit-2=0(PDC LL), Bit-3=0(PGD LL) */
+		3, 					/* Bit-0=1(PDC In), Bit-1=1(PGD In), Bit-2=0(PDC LL), Bit-3=0(PGD LL) */
 		SCR_SET_AUX,
-		1, /* Bit-0=1(Aux In), Bit-1=0(Aux LL) */
-		SCR_MCLR_GND_OFF,
-		SCR_VPP_OFF,
-		SCR_VDD_OFF,
-		SCR_BUSY_LED_OFF,
+		1, 					/* Bit-0=1(Aux In), Bit-1=0(Aux LL) */
+		/*SCR_VPP_PWM_OFF,*/
+		SCR_VDD_OFF,		/* Power OFF Vdd */
+		SCR_BUSY_LED_OFF,	/* Turn OFF Busy LED */
 		CMD_END_OF_BUFFER
 	};
+	int transferred = 0;
+	int ret = libusb_interrupt_transfer(pickit2_handle, ENDPOINT_OUT, command, USB_PACKET_LENGTH, &transferred, DFLT_TIMEOUT);
 
-	int ret = usb_interrupt_write(pickit2_handle, ENDPOINT_OUT, (char *)command, CMD_LENGTH, DFLT_TIMEOUT);
+	if (ret != 0) {
+		msg_perr("SPI Shutdown Script failed (%s)!\n", libusb_error_name(ret));
+	}
 
-	if (ret != CMD_LENGTH) {
-		msg_perr("Command Shutdown failed (%s)!\n", usb_strerror());
-		ret = 1;
+	ret = libusb_release_interface(pickit2_handle, 0);
+	if (ret != 0) {
+		msg_perr("Could not release USB interface (%s)!\n", libusb_error_name(ret));
+		ret = SPI_GENERIC_ERROR;
 	}
-	if (usb_release_interface(pickit2_handle, 0) != 0) {
-		msg_perr("Could not release USB interface!\n");
-		ret = 1;
-	}
-	if (usb_close(pickit2_handle) != 0) {
-		msg_perr("Could not close USB device!\n");
-		ret = 1;
-	}
+	libusb_close(pickit2_handle);
+	libusb_exit(usb_ctx);
+	
+	msg_pinfo("Shutdown succeeded\n");
+
 	return ret;
 }
 
 int pickit2_spi_init(void)
 {
-	unsigned int usedevice = 0; // FIXME: Allow selecting one of multiple devices
+	int usedevice = 0;
 
-	uint8_t buf[CMD_LENGTH] = {
+	uint8_t buf[USB_PACKET_LENGTH] = {
 		CMD_EXEC_SCRIPT,
-		10,			/* Script length */
+		8,					/* Script length */
 		SCR_SET_PINS,
-		2, /* Bit-0=0(PDC Out), Bit-1=1(PGD In), Bit-2=0(PDC LL), Bit-3=0(PGD LL) */
+		2,					/* Bit-0=0(PDC Out), Bit-1=1(PGD In), Bit-2=0(PDC LL), Bit-3=0(PGD LL) */
 		SCR_SET_AUX,
-		0, /* Bit-0=0(Aux Out), Bit-1=0(Aux LL) */
-		SCR_VDD_ON,
-		SCR_MCLR_GND_OFF,	/* Let CS# float */
-		SCR_VPP_PWM_ON,
-		SCR_VPP_ON,		/* Pull CS# high */
+		0,					/* Bit-0=0(Aux Out), Bit-1=0(Aux LL) */
+		SCR_VDD_ON,			/* Power ON Vdd */
+		SCR_MCLR_GND_Q_OFF,	/* Let CS# float */
+		SCR_VPP_Q_ON,		/* Pull CS# high */
+		/*SCR_VPP_PWM_ON,*/	/* no need to Power ON Vpp, CS# is internaly connected to Vdd */
+		SCR_BUSY_LED_ON,	/* Busy LED ON*/
+
+		CMD_CLR_DOWNLOAD_BUFFER,
+		CMD_CLR_UPLOAD_BUFFER,
+		CMD_CLR_SCRIPT_BUFFER,
+
+		CMD_DOWNLOAD_SCRIPT,
+		RUN_SCR_SPI_CS_HI,
+		2,
+		SCR_MCLR_GND_Q_OFF,
+		SCR_VPP_Q_ON,
+
+		CMD_DOWNLOAD_SCRIPT,
+		RUN_SCR_SPI_WRITE,
+		3,
+		SCR_VPP_Q_OFF,
+		SCR_MCLR_GND_Q_ON,
+		SCR_SPI_WRITE_BUFFER,
+
+		CMD_DOWNLOAD_SCRIPT,
+		RUN_SCR_SPI_READ,
+		3,
+		SCR_VPP_Q_OFF,
+		SCR_MCLR_GND_Q_ON,
+		SCR_SPI_READ_BUFFER,
+
+		CMD_DOWNLOAD_SCRIPT,
+		RUN_SCR_SPI_STATUS_REG,
+		4,
+		SCR_VPP_Q_OFF,
+		SCR_MCLR_GND_Q_ON,
+		SCR_SPI_WRITE_LIT,
+		JEDEC_RDSR,
+
+		CMD_DOWNLOAD_SCRIPT,
+		RUN_SCR_LED_ON,
+		1,
 		SCR_BUSY_LED_ON,
-		CMD_CLR_DLOAD_BUFF,
-		CMD_CLR_ULOAD_BUFF,
+
 		CMD_END_OF_BUFFER
 	};
 
+	unsigned int spispeed = PICKIT2_SCLK_MAX_kHz; /* 1 MHz */
+	char *spispeed_str = extract_programmer_param("spispeed");
+	if (spispeed_str != NULL) {
+		char* end_ptr = NULL;
+		errno = 0;
+		spispeed = strtoul(spispeed_str, &end_ptr, 10);
+		if ((errno != 0) || (spispeed_str == end_ptr)) {
+			msg_perr("Error: Could not convert 'spispeed'.\n");
+			free(spispeed_str);
+			return SPI_GENERIC_ERROR;
+		}
+		if (end_ptr && *end_ptr == 'M')
+			spispeed *= 1000;
 
-	int spispeed_idx = 0;
-	char *spispeed = extract_programmer_param("spispeed");
-	if (spispeed != NULL) {
-		int i = 0;
-		for (; spispeeds[i].name; i++) {
-			if (strcasecmp(spispeeds[i].name, spispeed) == 0) {
-				spispeed_idx = i;
-				break;
-			}
+		if ((spispeed == 0) || (spispeed > PICKIT2_SCLK_MAX_kHz) || (spispeed < 10)) {
+			msg_perr("Error: Value for 'spispeed' is out of range.\n");
+			free(spispeed_str);
+			return SPI_GENERIC_ERROR;
 		}
-		if (spispeeds[i].name == NULL) {
-			msg_perr("Error: Invalid 'spispeed' value.\n");
-			free(spispeed);
-			return 1;
-		}
-		free(spispeed);
+		free(spispeed_str);
 	}
 
-	int millivolt = 3500;
+	int millivolt = 3000;
+
 	char *voltage = extract_programmer_param("voltage");
 	if (voltage != NULL) {
 		millivolt = parse_voltage(voltage);
 		free(voltage);
 		if (millivolt < 0)
-			return 1;
+			return SPI_GENERIC_ERROR;
 	}
+	/* from dediproc.c */
+	char *device = extract_programmer_param("device");
+	if (device) {
+		char *dev_suffix = NULL;
+		errno = 0;
+		usedevice = strtol(device, &dev_suffix, 10);
+		if ((errno != 0) || (device == dev_suffix)) {
+			msg_perr("Error: Could not convert 'device'.\n");
+			free(device);
+			return SPI_GENERIC_ERROR;
+		}
+		if (usedevice < 0) {
+			msg_perr("Error: Value for 'device' is out of range.\n");
+			free(device);
+			return SPI_GENERIC_ERROR;
+		}
+		if (*dev_suffix) {
+			msg_perr("Error: Garbage following 'device' value.\n");
+			free(device);
+			return SPI_GENERIC_ERROR;
+		}
+		msg_pinfo("Using device %d.\n", usedevice);
+	}
+	free(device);
 
 	/* Here comes the USB stuff */
-	usb_init();
-	(void)usb_find_busses();
-	(void)usb_find_devices();
+	libusb_init(&usb_ctx);
+	if (!usb_ctx) {
+		msg_perr("Could not initialize libusb!\n");
+		return SPI_PROGRAMMER_ERROR;
+	}
+#if LIBUSB_API_VERSION >= 0x01000106
+	libusb_set_option(usb_ctx, LIBUSB_OPTION_LOG_LEVEL, LIBUSB_LOG_LEVEL_WARNING);
+#endif
 	const uint16_t vid = devs_pickit2_spi[0].vendor_id;
 	const uint16_t pid = devs_pickit2_spi[0].device_id;
- 	struct usb_device *dev = get_device_by_vid_pid(vid, pid, usedevice);
-	if (dev == NULL) {
+	
+	pickit2_handle = get_device_by_vid_pid_number(vid, pid, (unsigned int) usedevice);
+	if (pickit2_handle == NULL) {
 		msg_perr("Could not find a PICkit2 on USB!\n");
-		return 1;
+		libusb_exit(usb_ctx);
+		return SPI_PROGRAMMER_ERROR;
 	}
-	msg_pdbg("Found USB device (%04x:%04x).\n", dev->descriptor.idVendor, dev->descriptor.idProduct);
+    int config = 0;
+    int ret = libusb_get_configuration(pickit2_handle, &config);
+    if ((ret == LIBUSB_SUCCESS) && (config != 1)) {
+      ret = libusb_set_configuration(pickit2_handle, 1);
+	  if (ret != LIBUSB_SUCCESS) {
+		msg_perr("Could not set USB device configuration: %d %s\n", ret, libusb_error_name(ret));
+		libusb_close(pickit2_handle);
+		libusb_exit(usb_ctx);
+		return SPI_PROGRAMMER_ERROR;
+	  }
+    }
+    else if (ret != LIBUSB_SUCCESS) {
+      msg_perr("Could not get USB device configuration: %d %s\n", ret, libusb_error_name(ret));
+      libusb_close(pickit2_handle);
+      libusb_exit(usb_ctx);
+      return SPI_PROGRAMMER_ERROR;
+    }
+	ret = libusb_claim_interface(pickit2_handle, 0);
+	if (ret != LIBUSB_SUCCESS) {
+		msg_perr("Could not claim USB device interface %d: %d %s\n", 0, ret, libusb_error_name(ret));
+		libusb_close(pickit2_handle);
+		libusb_exit(usb_ctx);
+		return SPI_PROGRAMMER_ERROR;
+	}
+	if (register_shutdown(pickit2_shutdown, NULL)) {
+		return SPI_PROGRAMMER_ERROR;
+	}
 
-	pickit2_handle = usb_open(dev);
-	int ret = usb_set_configuration(pickit2_handle, 1);
-	if (ret != 0) {
-		msg_perr("Could not set USB device configuration: %i %s\n", ret, usb_strerror());
-		if (usb_close(pickit2_handle) != 0)
-			msg_perr("Could not close USB device!\n");
-		return 1;
-	}
-	ret = usb_claim_interface(pickit2_handle, 0);
-	if (ret != 0) {
-		msg_perr("Could not claim USB device interface %i: %i %s\n", 0, ret, usb_strerror());
-		if (usb_close(pickit2_handle) != 0)
-			msg_perr("Could not close USB device!\n");
-		return 1;
-	}
-
-	if (register_shutdown(pickit2_shutdown, NULL) != 0) {
-		return 1;
-	}
+	if (pickit2_get_status())
+		return SPI_PROGRAMMER_ERROR;
 
 	if (pickit2_get_firmware_version()) {
-		return 1;
+		return SPI_PROGRAMMER_ERROR;
 	}
 
-	/* Command Set SPI Speed */
-	if (pickit2_set_spi_speed(spispeed_idx)) {
-		return 1;
+	if (pickit2_set_spi_speed(spispeed)) {
+		return SPI_PROGRAMMER_ERROR;
 	}
 
-	/* Command Set SPI Voltage */
-	msg_pdbg("Setting voltage to %i mV.\n", millivolt);
 	if (pickit2_set_spi_voltage(millivolt) != 0) {
-		return 1;
+		return SPI_PROGRAMMER_ERROR;
 	}
 
 	/* Perform basic setup.
-	 * Configure pin directions and logic levels, turn Vdd on, turn busy LED on and clear buffers. */
-	ret = usb_interrupt_write(pickit2_handle, ENDPOINT_OUT, (char *)buf, CMD_LENGTH, DFLT_TIMEOUT);
-	if (ret != CMD_LENGTH) {
-		msg_perr("Command Setup failed (%s)!\n", usb_strerror());
-		return 1;
+	 * Configure pin directions and logic levels, turn Vdd on, turn busy LED on, clear buffers and download canned scripts. */
+	int transferred = 0;
+	ret = libusb_interrupt_transfer(pickit2_handle, ENDPOINT_OUT, buf, USB_PACKET_LENGTH, &transferred, DFLT_TIMEOUT);
+	if (ret != LIBUSB_SUCCESS) {
+		msg_perr("PicKit2 Setup Command failed (%s)!\n", libusb_error_name(ret));
+		return SPI_PROGRAMMER_ERROR;
 	}
 
 	register_spi_master(&spi_master_pickit2);


### PR DESCRIPTION
Recently I tried to use flashrom with PicKit2 on Windows.
I was unable to get it working with various libusb0 dll's,
so I rewrote pickit2_spi.c to use libusb 1.021 (form libusb.info).
Since other external USB programmers use libusb,
flashrom doesn't depend on obsolete libusb0 anymore.
This change is not platform dependant.
