### PR TITLE
added support for Adesto, formerly ATMEL, AT25DF021A flash device; te…

### DIFF
--- a/flashchips.c
+++ b/flashchips.c
@@ -1519,7 +1519,7 @@ const struct flashchip flashchips[] = {
 
 	{
 		.vendor		= "Atmel",
-		.name		= "AT25DF021",
+		.name		= "AT25DF021A",
 		.bustype	= BUS_SPI,
 		.manufacture_id	= ATMEL_ID,
 		.model_id	= ATMEL_AT25DF021A,
@@ -1553,7 +1553,7 @@ const struct flashchip flashchips[] = {
 		.unlock		= spi_disable_blockprotect_at2x_global_unprotect,
 		.write		= spi_chip_write_256,
 		.read		= spi_chip_read,
-		.voltage	= {2700, 3600}, /* 2.3-3.6V & 2.7-3.6V models available */
+		.voltage	= {1650, 3600},
 	},
 
 	{

--- a/flashchips.c
+++ b/flashchips.c
@@ -1519,6 +1519,45 @@ const struct flashchip flashchips[] = {
 
 	{
 		.vendor		= "Atmel",
+		.name		= "AT25DF021",
+		.bustype	= BUS_SPI,
+		.manufacture_id	= ATMEL_ID,
+		.model_id	= ATMEL_AT25DF021A,
+		.total_size	= 256,
+		.page_size	= 256,
+		/* OTP: 128B total, 64B pre-programmed; read 0x77; write 0x9B */
+		.feature_bits	= FEATURE_WRSR_WREN | FEATURE_OTP,
+		.tested		= TEST_OK_PREW,
+		.probe		= probe_spi_rdid,
+		.probe_timing	= TIMING_ZERO,
+		.block_erasers	=
+		{
+			{
+				.eraseblocks = { {4 * 1024, 64} },
+				.block_erase = spi_block_erase_20,
+			}, {
+				.eraseblocks = { {32 * 1024, 8} },
+				.block_erase = spi_block_erase_52,
+			}, {
+				.eraseblocks = { {64 * 1024, 4} },
+				.block_erase = spi_block_erase_d8,
+			}, {
+				.eraseblocks = { {256 * 1024, 1} },
+				.block_erase = spi_block_erase_60,
+			}, {
+				.eraseblocks = { {256 * 1024, 1} },
+				.block_erase = spi_block_erase_c7,
+			}
+		},
+		.printlock	= spi_prettyprint_status_register_at25df,
+		.unlock		= spi_disable_blockprotect_at2x_global_unprotect,
+		.write		= spi_chip_write_256,
+		.read		= spi_chip_read,
+		.voltage	= {2700, 3600}, /* 2.3-3.6V & 2.7-3.6V models available */
+	},
+
+	{
+		.vendor		= "Atmel",
 		.name		= "AT25DF041A",
 		.bustype	= BUS_SPI,
 		.manufacture_id	= ATMEL_ID,

--- a/flashchips.h
+++ b/flashchips.h
@@ -128,6 +128,7 @@
 
 #define ATMEL_ID		0x1F	/* Atmel (now used by Adesto) */
 #define ATMEL_AT25DF021		0x4300
+#define ATMEL_AT25DF021A	0x4301
 #define ATMEL_AT25DF041A	0x4401
 #define ATMEL_AT25DF081		0x4502	/* EDI 0x00. AT25DL081 has same ID + EDI 0x0100 */
 #define ATMEL_AT25DF081A	0x4501	/* Yes, 81A has a lower number than 81 */


### PR DESCRIPTION
added support for Adesto, formerly ATMEL, AT25DF021A flash device; tested with FT2232H Mini Module

Change-Id: I0a9acd67653647e077e4e9577c76df0a1eb37718
Signed-off-by: Steffen Mauch <steffen.mauch@gmail.com>