### PR TITLE
digilent_spi: Avoid deprecated libusb function

### DIFF
--- a/digilent_spi.c
+++ b/digilent_spi.c
@@ -386,7 +386,11 @@ int digilent_spi_init(void)
 		return -1;
 	}
 
+#if LIBUSB_API_VERSION < 0x01000106
 	libusb_set_debug(NULL, 3);
+#else
+	libusb_set_option(NULL, LIBUSB_OPTION_LOG_LEVEL, LIBUSB_LOG_LEVEL_INFO);
+#endif
 
 	uint16_t vid = devs_digilent_spi[0].vendor_id;
 	uint16_t pid = devs_digilent_spi[0].device_id;


### PR DESCRIPTION
Same logic used in ch341a_spi (291764a70e6d8b212680e311bfb0825abf2b9a2f)

Change-Id: I3546760ab70a5700b739bcaae8f1591730c172dc
Signed-off-by: Luke Street <luke.street@encounterpc.com>