### PR TITLE
Fremont Micro Devices FT25H04 support

### DIFF
--- a/flashchips.c
+++ b/flashchips.c
@@ -16928,6 +16928,43 @@ const struct flashchip flashchips[] = {
 	},
 
 	{
+                .vendor         = "FMD", /*http://famousconnections.eu/wp-content/uploads/2017/10/FT25H04.pdf*/
+                .name           = "FT25H04",
+                .bustype        = BUS_SPI,
+                .manufacture_id = FMD_ID,
+                .model_id       = FMD_FT25H04,
+                .total_size     = 512,
+                .page_size      = 256,
+                .feature_bits   = FEATURE_WRSR_WREN,
+                .tested         = TEST_UNTESTED,
+                .probe          = probe_spi_rdid,
+                .probe_timing   = TIMING_ZERO,
+                .block_erasers  =
+                {
+                        {
+                                .eraseblocks = { {4 * 1024, 128} },
+                                .block_erase = spi_block_erase_20,
+                        }, {
+                                .eraseblocks = { {64 * 1024, 8} },
+                                .block_erase = spi_block_erase_d8,
+                        }, {
+                                .eraseblocks = { {512 * 1024, 1} },
+                                .block_erase = spi_block_erase_60,
+                        }, {
+                                .eraseblocks = { {512 * 1024, 1} },
+                                .block_erase = spi_block_erase_c7,
+                        }
+                },
+                .printlock      = spi_prettyprint_status_register_bp2_srwd,
+                .unlock         = spi_disable_blockprotect_bp2_srwd,
+                .write          = spi_chip_write_256,
+                .read           = spi_chip_read, /* Fast read (0x0B) and multi I/O supported */
+                .voltage        = {2700, 3600},
+        },
+
+
+
+	{
 		.vendor		= "Generic",
 		.name		= "unknown SPI chip (RDID)",
 		.bustype	= BUS_SPI,

--- a/flashchips.c
+++ b/flashchips.c
@@ -16962,6 +16962,40 @@ const struct flashchip flashchips[] = {
                 .voltage        = {2700, 3600},
         },
 
+        {
+                .vendor         = "SFM", /*http://www.zhktl.com/uploadfile/download/20146131545443060.pdf*/
+                .name           = "FM25F04",
+                .bustype        = BUS_SPI,
+                .manufacture_id = SFM_ID,
+                .model_id       = SFM_FM25F04,
+                .total_size     = 512,
+                .page_size      = 256,
+                .feature_bits   = FEATURE_WRSR_WREN,
+                .tested         = TEST_UNTESTED,
+                .probe          = probe_spi_rdid,
+                .probe_timing   = TIMING_ZERO,
+                .block_erasers  =
+                {
+                        {
+                                .eraseblocks = { {4 * 1024, 128} },
+                                .block_erase = spi_block_erase_20,
+                        }, {
+                                .eraseblocks = { {64 * 1024, 8} },
+                                .block_erase = spi_block_erase_d8,
+                        }, {
+                                .eraseblocks = { {512 * 1024, 1} },
+                                .block_erase = spi_block_erase_60,
+                        }, {
+                                .eraseblocks = { {512 * 1024, 1} },
+                                .block_erase = spi_block_erase_c7,
+                        }
+                },
+                .printlock      = spi_prettyprint_status_register_bp2_srwd,
+                .unlock         = spi_disable_blockprotect_bp2_srwd,
+                .write          = spi_chip_write_256,
+                .read           = spi_chip_read, /* Fast read (0x0B) and multi I/O supported */
+                .voltage        = {2700, 3600},
+        },
 
 
 	{

--- a/flashchips.h
+++ b/flashchips.h
@@ -968,4 +968,7 @@
 #define FMD_ID            0x0E    /* Fremont Micro Devices */
 #define FMD_FT25H04        0x4013
 
+#define SFM_ID		  0xA1 /*Shanghai Fudan Microelectronics Group Company Limited*/
+#define SFM_FM25F04	  0x3113
+
 #endif /* !FLASHCHIPS_H */

--- a/flashchips.h
+++ b/flashchips.h
@@ -965,4 +965,7 @@
 #define ZETTADEVICE_ZD25D20     0x2012
 #define ZETTADEVICE_ZD25D40     0x2013
 
+#define FMD_ID            0x0E    /* Fremont Micro Devices */
+#define FMD_FT25H04        0x4013
+
 #endif /* !FLASHCHIPS_H */


### PR DESCRIPTION
Signed-off-by: Tomas kovacik <nail@nodomain.sk>

support for 25H04 by freemont micro devices, tested on 0.9.9 changing name on bluetooth module see[1], but it's just definition patch compile fine on 1.0, datasheet at [2]

[1] http://kovo-blog.blogspot.com/2017/11/bk8000l-change-name.html
[2] http://famousconnections.eu/wp-content/uploads/2017/10/FT25H04.pdf
