### PR TITLE
Add support for the Microchip MCP2210 USB to SPI bridge.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1112,7 +1112,8 @@ TAROPTIONS = $(shell LC_ALL=C tar --version|grep -q GNU && echo "--owner=root --
 # This includes all frontends and libflashrom.
 # We don't use EXEC_SUFFIX here because we want to clean everything.
 clean:
-	rm -f $(PROGRAM) $(PROGRAM).exe libflashrom.a *.o *.d $(PROGRAM).8 $(PROGRAM).8.html $(BUILD_DETAILS_FILE)
+	find -name "*.o" -or -name "*.d" -delete
+	rm -f $(PROGRAM) $(PROGRAM).exe libflashrom.a $(PROGRAM).8 $(PROGRAM).8.html $(BUILD_DETAILS_FILE)
 	@+$(MAKE) -C util/ich_descriptors_tool/ clean
 
 distclean: clean

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ CONFIG_DEFAULT_PROGRAMMER_ARGS ?= ''
 
 # If your compiler spits out excessive warnings, run make WARNERROR=no
 # You shouldn't have to change this flag.
-WARNERROR ?= yes
+WARNERROR ?= no
 
 ifeq ($(WARNERROR), yes)
 CFLAGS += -Werror
@@ -185,6 +185,14 @@ UNSUPPORTED_FEATURES += CONFIG_CH341A_SPI=yes
 else
 override CONFIG_CH341A_SPI = no
 endif
+
+# MCP2210 is Linux only for now
+ifeq ($(CONFIG_MCP2210_SPI), yes)
+UNSUPPORTED_FEATURES += CONFIG_MCP2210_SPI=yes
+else
+override CONFIG_MCP2210_SPI = no
+endif
+
 endif
 
 # FIXME: Should we check for Cygwin/MSVC as well?
@@ -281,6 +289,14 @@ UNSUPPORTED_FEATURES += CONFIG_SATAMV=yes
 else
 override CONFIG_SATAMV = no
 endif
+
+# MCP2210 is Linux only for now
+ifeq ($(CONFIG_MCP2210_SPI), yes)
+UNSUPPORTED_FEATURES += CONFIG_MCP2210_SPI=yes
+else
+override CONFIG_MCP2210_SPI = no
+endif
+
 endif
 
 ifeq ($(TARGET_OS), libpayload)
@@ -347,6 +363,14 @@ UNSUPPORTED_FEATURES += CONFIG_CH341A_SPI=yes
 else
 override CONFIG_CH341A_SPI = no
 endif
+
+# MCP2210 is Linux only for now
+ifeq ($(CONFIG_MCP2210_SPI), yes)
+UNSUPPORTED_FEATURES += CONFIG_MCP2210_SPI=yes
+else
+override CONFIG_MCP2210_SPI = no
+endif
+
 endif
 
 ifneq ($(TARGET_OS), Linux)
@@ -659,6 +683,9 @@ CONFIG_DIGILENT_SPI ?= yes
 # Disable wiki printing by default. It is only useful if you have wiki access.
 CONFIG_PRINT_WIKI ?= no
 
+# MCP2210 USB to SPI master bridge
+CONFIG_MCP2210_SPI ?= yes
+
 # Disable all features if CONFIG_NOTHING=yes is given unless CONFIG_EVERYTHING was also set
 ifeq ($(CONFIG_NOTHING), yes)
   ifeq ($(CONFIG_EVERYTHING), yes)
@@ -962,6 +989,13 @@ ifeq ($(CONFIG_DIGILENT_SPI), yes)
 FEATURE_CFLAGS += -D'CONFIG_DIGILENT_SPI=1'
 PROGRAMMER_OBJS += digilent_spi.o
 NEED_LIBUSB1 += CONFIG_DIGILENT_SPI
+endif
+
+ifeq ($(CONFIG_MCP2210_SPI), yes)
+FEATURE_CFLAGS += -D'CONFIG_MCP2210_SPI=1'
+PROGRAMMER_OBJS += libmcp2210/hid_linux.o libmcp2210/libmcp2210.o \
+	mcp2210_spi.o
+LIBS += -ludev
 endif
 
 ifneq ($(NEED_SERIAL), )

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ CONFIG_DEFAULT_PROGRAMMER_ARGS ?= ''
 
 # If your compiler spits out excessive warnings, run make WARNERROR=no
 # You shouldn't have to change this flag.
-WARNERROR ?= no
+WARNERROR ?= yes
 
 ifeq ($(WARNERROR), yes)
 CFLAGS += -Werror

--- a/flashrom.c
+++ b/flashrom.c
@@ -437,6 +437,18 @@ const struct programmer_entry programmer_table[] = {
 	},
 #endif
 
+#if CONFIG_MCP2210_SPI == 1
+	{
+		.name				= "mcp2210_spi",
+		.type				= USB,
+		.devs.note			= "MCP2210 USB to SPI master bridge",
+		.init				= mcp2210_spi_init,
+		.map_flash_region	= fallback_map,
+		.unmap_flash_region	= fallback_unmap,
+		.delay				= internal_delay,
+	},
+#endif
+
 	{0}, /* This entry corresponds to PROGRAMMER_INVALID. */
 };
 

--- a/libmcp2210/hid.h
+++ b/libmcp2210/hid.h
@@ -1,0 +1,32 @@
+/* HID module interface */
+#ifndef HID_H
+#define HID_H
+
+// Defined by each HID module
+typedef struct hid_handle hid_handle_t;
+
+// Initialize the HID module
+// Returns: 0 -> success; -1 -> error, errno is set
+int hid_init();
+
+// Find all HID devices with the specified VID and PID
+// Returns: number of devices found; -1 -> error, errno is set
+ssize_t hid_find_devices(uint16_t vid, uint16_t pid, hid_handle_t **dest, size_t dest_len);
+
+// Get a textual representation of a HID device
+const char *hid_device_desc(hid_handle_t *handle);
+
+// Write to HID device
+// Returns: number of bytes written; -1 -> error, errno is set
+ssize_t hid_write(hid_handle_t *handle, void *data, size_t data_len);
+
+// Read from an HID device
+// Returns: number of bytes read; -1 -> error, errno is set
+ssize_t hid_read(hid_handle_t *handle, void *buffer, size_t buffer_len);
+
+// Call when finished using a device
+void hid_cleanup_device(hid_handle_t *handle);
+
+// Call when finished using the HID module
+void hid_fini();
+#endif

--- a/libmcp2210/hid_linux.c
+++ b/libmcp2210/hid_linux.c
@@ -1,0 +1,131 @@
+/* HID support code on Linux */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <libudev.h>
+#include "hid.h"
+
+// HID handle
+struct hid_handle {
+	char *devpath;
+	int fd;
+};
+
+// udev handle
+static struct udev* udev = NULL;
+
+int hid_init()
+{
+	if (!udev) {
+		if (!(udev = udev_new()))
+			return -1;
+	}
+	return 0;
+}
+
+ssize_t hid_find_devices(uint16_t vid, uint16_t pid, hid_handle_t **dest, size_t dest_len)
+{
+	if (!udev) {
+		errno = EINVAL;
+		return -1;
+	}
+
+	if (!dest_len) {
+		errno = ENOMEM;
+		return -1;
+	}
+
+	struct udev_enumerate *enumerate = udev_enumerate_new(udev);
+	if (!enumerate)
+		goto err1;
+
+	udev_enumerate_add_match_subsystem(enumerate, "hidraw");
+	udev_enumerate_scan_devices(enumerate);
+
+	struct udev_list_entry *cur, *all = udev_enumerate_get_list_entry(enumerate);
+	if (!all)
+		goto err2;
+
+	size_t i = 0;
+	udev_list_entry_foreach(cur, all) {
+		struct udev_device *device =
+		udev_device_new_from_syspath(udev, udev_list_entry_get_name(cur));
+		if (!device)
+			goto err2;
+
+		struct udev_device *parent =
+		udev_device_get_parent_with_subsystem_devtype(
+			device, "usb", "usb_device");
+
+		if (!parent) // Ignore non-usb HID devices
+			goto loop_cleanup;
+
+		uint16_t cur_vid = (uint16_t) strtol(udev_device_get_sysattr_value(parent, "idVendor"), NULL, 16);
+		uint16_t cur_pid = (uint16_t) strtol(udev_device_get_sysattr_value(parent, "idProduct"), NULL, 16);
+		if (cur_vid == vid && cur_pid == pid) {
+			struct hid_handle *handle = malloc(sizeof(struct hid_handle));
+			handle->devpath = strdup(udev_device_get_devnode(device));
+			handle->fd = -1;
+			dest[i++] = handle;
+		}
+
+		loop_cleanup:
+		udev_device_unref(device);
+		if (i >= dest_len) {
+			errno = ENOMEM;
+			goto err2;
+		}
+	}
+
+	udev_enumerate_unref(enumerate);
+	return (ssize_t) i;
+	err2:
+	udev_enumerate_unref(enumerate);
+	err1:
+	return -1;
+}
+
+const char *hid_device_desc(hid_handle_t *handle)
+{
+	return handle->devpath;
+}
+
+ssize_t hid_write(struct hid_handle *handle, void *data, size_t data_len)
+{
+	if (handle->fd == -1) {
+		handle->fd = open(handle->devpath, O_RDWR);
+		if (handle->fd == -1)
+			return -1;
+	}
+	return write(handle->fd, data, data_len);
+}
+
+ssize_t hid_read(struct hid_handle *handle, void *buffer, size_t buffer_len)
+{
+	if (handle->fd == -1) {
+		handle->fd = open(handle->devpath, O_RDWR);
+		if (handle->fd == -1)
+			return -1;
+	}
+	return read(handle->fd, buffer, buffer_len);
+}
+
+void hid_cleanup_device(struct hid_handle *handle)
+{
+	if (handle->fd != -1)
+		close(handle->fd);
+	free(handle->devpath);
+	free(handle);
+}
+
+void hid_fini()
+{
+	if (udev) {
+		udev_unref(udev);
+		udev = NULL;
+	}
+}

--- a/libmcp2210/libmcp2210.c
+++ b/libmcp2210/libmcp2210.c
@@ -1,0 +1,116 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+#include <errno.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include "hid.h"
+#include "libmcp2210.h"
+
+////
+// Commands
+////
+#define MCP2210_CMD_SET_CHIP_SETTINGS 0x21
+#define MCP2210_CMD_SET_SPI_SETTINGS  0x40
+#define MCP2210_CMD_TRANSFER_SPI_DATA 0x42
+
+typedef struct mcp2210_packet {
+	// Packet header
+	uint8_t hdr[4];
+
+	// Data structures
+	union {
+		mcp2210_spi_settings_t spi_settings;
+		mcp2210_chip_settings_t chip_settings;
+		uint8_t raw[60];
+	} __attribute__((packed)) data;
+} __attribute__((packed)) mcp2210_packet_t;
+
+static inline int do_usb_cmd(hid_handle_t *handle,
+	mcp2210_packet_t *cmd, mcp2210_packet_t *resp)
+{
+	if (-1 == hid_write(handle, cmd, sizeof(*cmd)))
+		return -1;
+	if (-1 == hid_read(handle, resp, sizeof(*resp)))
+		return -1;
+	return 0;
+}
+
+static inline void prepare_cmd(mcp2210_packet_t *cmd, uint8_t hdr_0, uint8_t hdr_1)
+{
+	bzero(cmd, sizeof(*cmd));
+	cmd->hdr[0] = hdr_0;
+	cmd->hdr[1] = hdr_1;
+}
+
+// Write chip settings
+int mcp2210_chip_settings(hid_handle_t *handle,mcp2210_chip_settings_t *chip_settings)
+{
+	mcp2210_packet_t cmd;
+	prepare_cmd(&cmd, MCP2210_CMD_SET_CHIP_SETTINGS, 0);
+	cmd.data.chip_settings = *chip_settings;
+
+	mcp2210_packet_t resp;
+	if (-1 == do_usb_cmd(handle, &cmd, &resp))
+		return -1;
+
+	if (resp.hdr[0] != cmd.hdr[0] || resp.hdr[1] != 0) {
+		errno = EACCES;
+		return -1;
+	}
+
+	return 0;
+}
+
+// Write SPI settings
+int mcp2210_spi_settings(hid_handle_t *handle, mcp2210_spi_settings_t *spi_settings)
+{
+	mcp2210_packet_t cmd;
+	prepare_cmd(&cmd, MCP2210_CMD_SET_SPI_SETTINGS, 0);
+	cmd.data.spi_settings = *spi_settings;
+
+	mcp2210_packet_t resp;
+	if (-1 == do_usb_cmd(handle, &cmd, &resp))
+		return -1;
+
+	if (resp.hdr[0] != cmd.hdr[0] || resp.hdr[1] != 0) {
+		errno = EACCES;
+		return -1;
+	}
+
+	return 0;
+}
+
+// Do an SPI transfer
+int mcp2210_spi_transfer(hid_handle_t *handle,
+	size_t data_len, void *data, mcp2210_spi_result_t *result)
+{
+	assert(data_len <= 60); // Max data bytes per HID packet
+
+	mcp2210_packet_t cmd;
+	prepare_cmd(&cmd, MCP2210_CMD_TRANSFER_SPI_DATA, data_len);
+	memcpy(cmd.data.raw, data, data_len);
+
+	mcp2210_packet_t resp;
+	if (-1 == do_usb_cmd(handle, &cmd, &resp)) {
+		return -1;
+	}
+
+	if (resp.hdr[0] != cmd.hdr[0]) {
+		errno = EACCES;
+		return -1;
+	}
+	if (resp.hdr[1] == 0xf7) {
+		errno = EBUSY;
+		return -1;
+	}
+
+	bzero(result, sizeof(mcp2210_spi_result_t));
+	result->status = resp.hdr[1];
+	result->spi_status = resp.hdr[3];
+	result->data_len = resp.hdr[2];
+	memcpy(result->data, resp.data.raw, result->data_len);
+
+	return 0;
+}

--- a/libmcp2210/libmcp2210.h
+++ b/libmcp2210/libmcp2210.h
@@ -1,0 +1,75 @@
+#ifndef LIBMCP2210_H
+#define LIBMCP2210_H
+
+// Byteswapping required on big-endian platforms
+#ifdef LITTLE_ENDIAN
+#define b16(x) x
+#define b32(x) x
+#elif defined BIG_ENDIAN
+#define b16(x) __builtin_bswap16(x)
+#define b32(x) __builtin_bswap32(x)
+#else
+#error Unsupported endianness
+#endif
+
+// Factory VID and PID of the MCP2210
+#define MCP2210_VID 0x04d8
+#define MCP2210_PID 0x00de
+
+// Chip settings
+#define MCP2210_PIN_GPIO 0
+#define MCP2210_PIN_CS 1
+#define MCP2210_PIN_DEDICATED 2
+
+#define MCP2210_BUS_RELEASE_DISABLE 1
+
+typedef struct mcp2210_chip_settings {
+	uint8_t  pins[9];
+	uint16_t gpio_default;
+	uint16_t gpio_direction;
+	uint8_t  other_settings;
+	uint8_t  nvram_lock;
+	uint8_t  new_password[8];
+} __attribute__((packed)) mcp2210_chip_settings_t;
+
+// Write chip settings
+int mcp2210_chip_settings(hid_handle_t *handle, mcp2210_chip_settings_t *chip_settings);
+
+// SPI settings
+#define MCP2210_MIN_BITRATE 1464
+#define MCP2210_MAX_BITRATE 12000000
+
+typedef struct mcp2210_spi_settings {
+	uint32_t bitrate;
+	uint16_t idle_cs;
+	uint16_t active_cs;
+	// CS assert to first data byte delay
+	uint16_t cs_to_data_delay;
+	// Last data byte to CS assert delay
+	uint16_t data_to_cs_delay;
+	// Delay between subsequent data bytes
+	uint16_t data_delay;
+	uint16_t bytes_per_transaction;
+	uint8_t spi_mode;
+} __attribute__((packed)) mcp2210_spi_settings_t;
+
+// Write SPI settings
+int mcp2210_spi_settings(hid_handle_t *handle, mcp2210_spi_settings_t *spi_settings);
+
+// SPI engine status
+#define MCP2210_SPI_STATUS_FINISHED    0x10
+#define MCP2210_SPI_STATUS_NO_DATA     0x20
+#define MCP2210_SPI_STATUS_DATA_NEEDED 0x30
+
+// Do an SPI transfer
+typedef struct mcp2210_spi_result {
+	int status;
+	uint8_t spi_status;
+	uint8_t data_len;
+	uint8_t data[60];
+} mcp2210_spi_result_t;
+
+int mcp2210_spi_transfer(hid_handle_t *handle,
+	size_t data_len, void *data, mcp2210_spi_result_t *result);
+
+#endif

--- a/mcp2210_spi.c
+++ b/mcp2210_spi.c
@@ -32,7 +32,10 @@ static mcp2210_chip_settings_t chip_settings = {
 
 // SPI settings
 static mcp2210_spi_settings_t spi_settings = {
-	.bitrate				= b32(8000000),
+	// there is no need for a higher bitrate, because
+	// the MCP2210 cannot push data any faster over HID
+	// to the host computer
+	.bitrate				= b32(750000),
 	.idle_cs				= b16(1),
 	.active_cs				= b16(0),
 	.cs_to_data_delay		= b16(0),
@@ -55,7 +58,7 @@ static int mcp2210_spi_send_command(struct flashctx *flash,
 	// And doing multiple transfers
 	assert(transfer_total <= 0xffff);
 
-	// Setting this on every command is a MAJOR bottleneck
+	// Set the transfer length if it changed
 	if (spi_settings.bytes_per_transaction != b16(transfer_total)) {
 		spi_settings.bytes_per_transaction = b16(transfer_total);
 		if (-1 == mcp2210_spi_settings(mcp2210_handle, &spi_settings)) {

--- a/mcp2210_spi.c
+++ b/mcp2210_spi.c
@@ -1,0 +1,177 @@
+// Flashrom programmer for the MCP2210 chip
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <assert.h>
+#include "programmer.h"
+#include "libmcp2210/hid.h"
+#include "libmcp2210/libmcp2210.h"
+
+static hid_handle_t *mcp2210_handle;
+
+// Chip settings
+// FIXME: implement a way to use another chip select line than CS0
+static mcp2210_chip_settings_t chip_settings = {
+	.pins = {
+		MCP2210_PIN_CS,
+		MCP2210_PIN_GPIO,
+		MCP2210_PIN_GPIO,
+		MCP2210_PIN_GPIO,
+		MCP2210_PIN_GPIO,
+		MCP2210_PIN_GPIO,
+		MCP2210_PIN_GPIO,
+		MCP2210_PIN_GPIO,
+		MCP2210_PIN_GPIO
+	},
+	.gpio_default = 0,
+	.gpio_direction = 0,
+	.other_settings = 0,
+	.nvram_lock = 0,
+	.new_password = { 0, 0, 0, 0, 0, 0, 0, 0 }
+};
+
+// SPI settings
+static mcp2210_spi_settings_t spi_settings = {
+	.bitrate				= b32(8000000),
+	.idle_cs				= b16(1),
+	.active_cs				= b16(0),
+	.cs_to_data_delay		= b16(0),
+	.data_to_cs_delay		= b16(0),
+	.data_delay				= b16(0),
+	.bytes_per_transaction	= b16(0), // set this for each command
+	.spi_mode				= 0
+};
+
+static int mcp2210_spi_send_command(struct flashctx *flash,
+	unsigned int writecnt, unsigned int readcnt,
+	const unsigned char *writearr, unsigned char *readarr)
+{
+	//printf("\nCMD: W: %d R: %d\n", writecnt, readcnt);
+
+	size_t transfer_total = writecnt + readcnt;
+	assert(transfer_total <= 0xffff);
+
+	// Setting this on every command is a MAJOR bottleneck
+	if (spi_settings.bytes_per_transaction != b16(transfer_total)) {
+		spi_settings.bytes_per_transaction = b16(transfer_total);
+		if (-1 == mcp2210_spi_settings(mcp2210_handle, &spi_settings)) {
+			perror("Failed to set MCP2210 SPI settings");
+			return -1;
+		}
+	}
+
+	// Write buffer
+	uint8_t write_buf[transfer_total];
+	uint8_t *write_ptr = write_buf;
+
+	bzero(write_buf, transfer_total);
+	memcpy(write_buf, writearr, writecnt);
+
+	// Read buffer
+	uint8_t read_buf[transfer_total];
+	uint8_t *read_ptr = read_buf;
+
+	size_t write_left = transfer_total;
+	size_t read_left = transfer_total;
+
+	// SPI result
+	mcp2210_spi_result_t result;
+
+	while (write_left || read_left) {
+		size_t write_current = write_left > 60 ? 60 : write_left;
+
+		if (-1 == mcp2210_spi_transfer(mcp2210_handle, write_current, write_ptr,
+				&result)) {
+			perror("SPI transfer failed");
+			return -1;
+		}
+
+		if (result.status == 0xf8) // retry
+			continue;
+
+		write_left -= write_current;
+		write_ptr += write_current;
+
+		if (result.data_len) {
+			if (read_left < result.data_len) {
+				fprintf(stderr, "WARN: MCP2210 sent more data than expected\n");
+			} else {
+				memcpy(read_ptr, result.data, result.data_len);
+				read_left -= result.data_len;
+				read_ptr += result.data_len;
+			}
+		}
+
+		if (result.spi_status == MCP2210_SPI_STATUS_FINISHED
+			&& (write_left || read_left)) {
+			fprintf(stderr, "ERR: MCP2210 sent less data than expected\n");
+			return -1;
+		}
+	}
+
+	/*printf("\n");
+	for (size_t i = 0; i < transfer_total; ++i) {
+		printf("%02x\n", read_buf[i]);
+	}
+	printf("\n");*/
+
+	memcpy(readarr, read_buf + writecnt, readcnt);
+	return 0;
+}
+
+static const struct spi_master spi_master_mcp2210_spi = {
+	.type			= SPI_CONTROLLER_MCP2210_SPI,
+	.features		= SPI_MASTER_4BA,
+	.max_data_read	= 0x7fff,
+	.max_data_write	= 0x7fff,
+	.command		= mcp2210_spi_send_command,
+	.multicommand	= default_spi_send_multicommand,
+	.read			= default_spi_read,
+	.write_256		= default_spi_write_256,
+	.write_aai		= default_spi_write_aai,
+};
+
+static int mcp2210_spi_shutdown()
+{
+	hid_cleanup_device(mcp2210_handle);
+	hid_fini();
+	return 0;
+}
+
+int mcp2210_spi_init()
+{
+	if (-1 == hid_init()) {
+		perror("Failed to initialize HID library");
+		return -1;
+	}
+
+	// Try locating the MCP2210
+	hid_handle_t *devices[10];
+	ssize_t device_count =
+		hid_find_devices(MCP2210_VID, MCP2210_PID, devices, 10);
+	if (-1 == device_count) {
+		perror("Searching for HID devices failed");
+		goto err;
+	}
+	if (1 != device_count) {
+		fprintf(stderr,
+			"Please have one and only one MCP2210 device plugged in\n");
+		for (size_t i = 0; i < device_count; ++i)
+			hid_cleanup_device(devices[i]);
+		goto err;
+	}
+
+	mcp2210_handle = devices[0];
+	if (-1 == mcp2210_chip_settings(mcp2210_handle, &chip_settings)) {
+		perror("Failed to configure MCP2210");
+		hid_cleanup_device(mcp2210_handle);
+		goto err;
+	}
+
+	register_shutdown(mcp2210_spi_shutdown, NULL);
+	register_spi_master(&spi_master_mcp2210_spi);
+	return 0;
+err:
+	hid_fini();
+	return -1;
+}

--- a/mcp2210_spi.c
+++ b/mcp2210_spi.c
@@ -49,6 +49,10 @@ static int mcp2210_spi_send_command(struct flashctx *flash,
 	//printf("\nCMD: W: %d R: %d\n", writecnt, readcnt);
 
 	size_t transfer_total = writecnt + readcnt;
+
+	// This is the technical transfer limit of the MCP2210
+	// In theory this can be avoided by using GPIO as chip select
+	// And doing multiple transfers
 	assert(transfer_total <= 0xffff);
 
 	// Setting this on every command is a MAJOR bottleneck

--- a/programmer.h
+++ b/programmer.h
@@ -118,6 +118,9 @@ enum programmer {
 #if CONFIG_DIGILENT_SPI == 1
 	PROGRAMMER_DIGILENT_SPI,
 #endif
+#if CONFIG_MCP2210_SPI == 1
+	PROGRAMMER_MCP2210_SPI,
+#endif
 	PROGRAMMER_INVALID /* This must always be the last entry. */
 };
 
@@ -573,6 +576,10 @@ int digilent_spi_init(void);
 extern const struct dev_entry devs_digilent_spi[];
 #endif
 
+#if CONFIG_MCP2210_SPI == 1
+int mcp2210_spi_init();
+#endif
+
 /* flashrom.c */
 struct decode_sizes {
 	uint32_t parallel;
@@ -640,6 +647,9 @@ enum spi_controller {
 #endif
 #if CONFIG_DIGILENT_SPI == 1
 	SPI_CONTROLLER_DIGILENT_SPI,
+#endif
+#if CONFIG_MCP2210_SPI == 1
+	SPI_CONTROLLER_MCP2210_SPI,
 #endif
 };
 


### PR DESCRIPTION
Support for the MCP2210 USB to SPI bridge by Microchip.
Datasheet: [link](http://ww1.microchip.com/downloads/en/DeviceDoc/22288A.pdf)
I do not really know how to format this correctly for flashrom, but it is based on a simplified version of my library for the chip [libmcp2210](https://github.com/kukrimate/libmcp2210).
At the moment it uses the hidraw interface directly and libudev for finding the device. Should I use libusb for this, does it actually support HID devices?
I have tested this with the SPI flasher breakout board I designed for this chip. [spi_flasher](https://github.com/kukrimate/spi_flasher)
I only tested it with a W25Q64.V 8MB and Pm25LD010(C) (128KB) and it seems to work, but there is still room for improvements.

Change-Id: If8aff228d2d442de7ccdc5a210e32e888f918b9e
Signed-off-by: Máté Kukri <kukri.mate@gmail.com>