### PR TITLE
 Added ST95XXX chips support. 

### DIFF
--- a/chipdrivers.h
+++ b/chipdrivers.h
@@ -34,6 +34,7 @@ int probe_spi_rems(struct flashctx *flash);
 int probe_spi_res1(struct flashctx *flash);
 int probe_spi_res2(struct flashctx *flash);
 int probe_spi_res3(struct flashctx *flash);
+int probe_spi_st_95(struct flashctx *flash);
 int probe_spi_at25f(struct flashctx *flash);
 int spi_write_enable(struct flashctx *flash);
 int spi_write_disable(struct flashctx *flash);
@@ -51,7 +52,9 @@ int spi_block_erase_d7(struct flashctx *flash, unsigned int addr, unsigned int b
 int spi_block_erase_d8(struct flashctx *flash, unsigned int addr, unsigned int blocklen);
 int spi_block_erase_db(struct flashctx *flash, unsigned int addr, unsigned int blocklen);
 int spi_block_erase_dc(struct flashctx *flash, unsigned int addr, unsigned int blocklen);
+int spi_block_erase_emulation(struct flashctx *flash, unsigned int addr, unsigned int blocklen);
 erasefunc_t *spi_get_erasefn_from_opcode(uint8_t opcode);
+int spi_nbyte_program(struct flashctx *flash, unsigned int addr, const uint8_t *bytes, unsigned int len);
 int spi_chip_write_1(struct flashctx *flash, const uint8_t *buf, unsigned int start, unsigned int len);
 int spi_nbyte_read(struct flashctx *flash, unsigned int addr, uint8_t *bytes, unsigned int len);
 int spi_read_chunked(struct flashctx *flash, uint8_t *buf, unsigned int start, unsigned int len, unsigned int chunksize);

--- a/cli_classic.c
+++ b/cli_classic.c
@@ -506,7 +506,7 @@ int main(int argc, char *argv[])
 	for (j = 0; j < registered_master_count; j++) {
 		startchip = 0;
 		while (chipcount < ARRAY_SIZE(flashes)) {
-			startchip = probe_flash(&registered_masters[j], startchip, &flashes[chipcount], 0);
+			startchip = probe_flash(&registered_masters[j], startchip, &flashes[chipcount], (chip_to_probe) && force );
 			if (startchip == -1)
 				break;
 			chipcount++;
@@ -549,7 +549,7 @@ int main(int argc, char *argv[])
 					  "chip, using the first one.\n");
 			for (j = 0; j < registered_master_count; j++) {
 				mst = &registered_masters[j];
-				startchip = probe_flash(mst, 0, &flashes[0], 1);
+				startchip = probe_flash(mst, 0, &flashes[0], 2);
 				if (startchip != -1)
 					break;
 			}

--- a/flash.h
+++ b/flash.h
@@ -134,6 +134,8 @@ enum write_granularity {
  */
 #define FEATURE_ERASED_ZERO	(1 << 17)
 #define FEATURE_NO_ERASE	(1 << 18)
+#define FEATURE_SHORT_ADDR_LEN	(1 << 19)
+#define FEATURE_IDENTITY_MISSING	(1 << 20)
 
 #define ERASED_VALUE(flash)	(((flash)->chip->feature_bits & FEATURE_ERASED_ZERO) ? 0x00 : 0xff)
 

--- a/flashchips.c
+++ b/flashchips.c
@@ -15151,6 +15151,188 @@ const struct flashchip flashchips[] = {
 		.voltage	= {3000, 3600}, /* Also has 12V fast program & erase */
 	},
 
+//    {
+//            .vendor		= "ST",
+//            .name		= "M95040",
+//            .bustype	= BUS_SPI,
+//            .manufacture_id	= ST_ID,
+//            .model_id	= ST_M95040,
+//            .total_size	= 512,
+//            .page_size	= 16,
+//            .feature_bits	= FEATURE_WRSR_WREN | FEATURE_SHORT_ADDR_LEN| FEATURE_CAPACITY_IN_BYTE | FEATURE_IDENTITY_MISSING,
+//            .tested		= TEST_UNTESTED,/* {.probe = BAD, .read = OK, .erase = OK, .write = OK },*/
+//            .probe		= probe_spi_st_95,
+//            .probe_timing	= TIMING_ZERO,
+//            .block_erasers	=
+//                    {
+//                            {
+//                                    .eraseblocks = { { 512 * 1, 1 } },
+//                                    .block_erase = spi_block_erase_emulation,
+//                            }
+//                    },
+//            .printlock	= spi_prettyprint_status_register_bp1_srwd,
+//            .unlock		= spi_disable_blockprotect_bp1_srwd,
+//            .write		= spi_chip_write_1,
+//            .read		= spi_chip_read,
+//            .voltage	= {2500, 5500},
+//    },
+
+    {
+            .vendor		= "ST",
+            .name		= "M95080",
+            .bustype	= BUS_SPI,
+            .manufacture_id	= ST_ID,
+            .model_id	= ST_M95080,
+            .total_size	= 1,
+            .page_size	= 32,
+            .feature_bits	= FEATURE_WRSR_WREN | FEATURE_SHORT_ADDR_LEN | FEATURE_IDENTITY_MISSING,
+            .tested		= {.probe = OK, .read = OK, .erase = OK, .write = OK },
+            .probe		= probe_spi_st_95,
+            .probe_timing	= TIMING_ZERO,
+            .block_erasers	=
+                    {
+                            {
+                                    .eraseblocks = { { 1 * 1024, 1 } },
+                                    .block_erase = spi_block_erase_emulation,
+                            }
+                    },
+            .printlock	= spi_prettyprint_status_register_bp1_srwd,
+            .unlock		= spi_disable_blockprotect_bp1_srwd,
+            .write		= spi_chip_write_1,
+            .read		= spi_chip_read,
+            .voltage	= {2500, 5500},
+    },
+
+    {
+            .vendor		= "ST",
+            .name		= "M95160",
+            .bustype	= BUS_SPI,
+            .manufacture_id	= ST_ID,
+            .model_id	= ST_M95160,
+            .total_size	= 2,
+            .page_size	= 32,
+            .feature_bits	= FEATURE_WRSR_WREN | FEATURE_SHORT_ADDR_LEN | FEATURE_IDENTITY_MISSING,
+            .tested		= {.probe = OK, .read = OK, .erase = OK, .write = OK },
+            .probe		= probe_spi_st_95,
+            .probe_timing	= TIMING_ZERO,
+            .block_erasers	=
+                    {
+                            {
+                                    .eraseblocks = { { 2 * 1024, 1 } },
+                                    .block_erase = spi_block_erase_emulation,
+                            }
+                    },
+            .printlock	= spi_prettyprint_status_register_bp1_srwd,
+            .unlock		= spi_disable_blockprotect_bp1_srwd,
+            .write		= spi_chip_write_1,
+            .read		= spi_chip_read,
+            .voltage	= {2500, 5500},
+    },
+
+    {
+            .vendor		= "ST",
+            .name		= "M95320",
+            .bustype	= BUS_SPI,
+            .manufacture_id	= ST_ID,
+            .model_id	= ST_M95320,
+            .total_size	= 4,
+            .page_size	= 32,
+            .feature_bits	= FEATURE_WRSR_WREN | FEATURE_SHORT_ADDR_LEN | FEATURE_IDENTITY_MISSING,
+            .tested		= {.probe = OK, .read = OK, .erase = OK, .write = OK },
+            .probe		= probe_spi_st_95,
+            .probe_timing	= TIMING_ZERO,
+            .block_erasers	=
+                    {
+                            {
+                                    .eraseblocks = { { 4 * 1024, 1 } },
+                                    .block_erase = spi_block_erase_emulation,
+                            }
+                    },
+            .printlock	= spi_prettyprint_status_register_bp1_srwd,
+            .unlock		= spi_disable_blockprotect_bp1_srwd,
+            .write		= spi_chip_write_1,
+            .read		= spi_chip_read,
+            .voltage	= {2500, 5500},
+    },
+
+    {
+            .vendor		= "ST",
+            .name		= "M95640",
+            .bustype	= BUS_SPI,
+            .manufacture_id	= ST_ID,
+            .model_id	= ST_M95640,
+            .total_size	= 8,
+            .page_size	= 32,
+            .feature_bits	= FEATURE_WRSR_WREN | FEATURE_SHORT_ADDR_LEN | FEATURE_IDENTITY_MISSING,
+            .tested		= {.probe = OK, .read = OK, .erase = OK, .write = OK },
+            .probe		= probe_spi_st_95,
+            .probe_timing	= TIMING_ZERO,
+            .block_erasers	=
+                    {
+                            {
+                                    .eraseblocks = { { 8 * 1024, 1 } },
+                                    .block_erase = spi_block_erase_emulation,
+                            }
+                    },
+            .printlock	= spi_prettyprint_status_register_bp1_srwd,
+            .unlock		= spi_disable_blockprotect_bp1_srwd,
+            .write		= spi_chip_write_1,
+            .read		= spi_chip_read,
+            .voltage	= {2500, 5500},
+    },
+
+    {
+            .vendor		= "ST",
+            .name		= "M95128",
+            .bustype	= BUS_SPI,
+            .manufacture_id	= ST_ID,
+            .model_id	= ST_M95128,
+            .total_size	= 16,
+            .page_size	= 64,
+            .feature_bits	= FEATURE_WRSR_WREN | FEATURE_SHORT_ADDR_LEN | FEATURE_IDENTITY_MISSING,
+            .tested		= {.probe = OK, .read = OK, .erase = OK, .write = OK },
+            .probe		= probe_spi_st_95,
+            .probe_timing	= TIMING_ZERO,
+            .block_erasers	=
+                    {
+                            {
+                                    .eraseblocks = { { 16 * 1024, 1 } },
+                                    .block_erase = spi_block_erase_emulation,
+                            }
+                    },
+            .printlock	= spi_prettyprint_status_register_bp1_srwd,
+            .unlock		= spi_disable_blockprotect_bp1_srwd,
+            .write		= spi_chip_write_1,
+            .read		= spi_chip_read,
+            .voltage	= {2500, 5500},
+    },
+
+    {
+            .vendor		= "ST",
+            .name		= "M95256",
+            .bustype	= BUS_SPI,
+            .manufacture_id	= ST_ID,
+            .model_id	= ST_M95256,
+            .total_size	= 32,
+            .page_size	= 64,
+            .feature_bits	= FEATURE_WRSR_WREN | FEATURE_SHORT_ADDR_LEN | FEATURE_IDENTITY_MISSING,
+            .tested		= {.probe = OK, .read = OK, .erase = OK, .write = OK },
+            .probe		= probe_spi_st_95,
+            .probe_timing	= TIMING_ZERO,
+            .block_erasers	=
+                    {
+                            {
+                                    .eraseblocks = { { 32 * 1024, 1 } },
+                                    .block_erase = spi_block_erase_emulation,
+                            }
+                    },
+            .printlock	= spi_prettyprint_status_register_bp1_srwd,
+            .unlock		= spi_disable_blockprotect_bp1_srwd,
+            .write		= spi_chip_write_1,
+            .read		= spi_chip_read,
+            .voltage	= {2500, 5500},
+    },
+
 	{
 		.vendor		= "SyncMOS/MoselVitelic",
 		.name		= "{F,S,V}29C51001B",

--- a/flashchips.h
+++ b/flashchips.h
@@ -852,6 +852,16 @@
 #define ST_M58WR032KT		0x8814
 #define ST_M58WR064KB		0x8811
 #define ST_M58WR064KT		0x8810
+/* 00h Memory Density code ST_ID*/
+/* 01h SPI Family code     0x00*/
+/* 02h Memory Density code ST_M95XXX */
+#define ST_M95040           0x0009
+#define ST_M95080           0x000A
+#define ST_M95160           0x000B
+#define ST_M95320           0x000C
+#define ST_M95640           0x000D
+#define ST_M95128           0x000E
+#define ST_M95256           0x000F
 #define ST_MT28GU01G___1	0x88B0
 #define ST_MT28GU01G___2	0x88B1
 #define ST_MT28GU256___1	0x8901

--- a/spi.h
+++ b/spi.h
@@ -21,12 +21,36 @@
  */
 
 #define JEDEC_MAX_ADDR_LEN	0x04
+#define JEDEC_SHORT_ADDR_LEN	0x03
 
 /* Read Electronic ID */
 #define JEDEC_RDID		0x9f
 #define JEDEC_RDID_OUTSIZE	0x01
 /* INSIZE may be 0x04 for some chips*/
 #define JEDEC_RDID_INSIZE	0x03
+
+/* Some ST M95X model  */
+#define ST_M95_RDID		        0x83
+#define ST_M95_RDID_OUTSIZE	    0x03
+#define ST_M95_RDID_INSIZE  	0x03
+#define ST_M95_RDLS		        0x83
+#define ST_M95_RDLS_OUTSIZE	    0x03
+#define ST_M95_RDLS_INSIZE  	0x01
+#define ST_M95_RDSR		        0x05
+#define ST_M95_RDSR_OUTSIZE	    0x01
+#define ST_M95_RDSR_INSIZE	    0x01
+#define ST_M95_READ		        0x03
+#define ST_M95_READ_OUTSIZE 	0x03
+#define ST_M95_READ_INSIZE  	0x03
+#define ST_M95_WREN 	        0x06
+#define ST_M95_WREN_OUTSIZE     0x01
+#define ST_M95_WREN_INSIZE      0x00
+#define ST_M95_WRITE	        0x02
+#define ST_M95_WRITE_OUTSIZE	0x06
+#define ST_M95_WRITE_INSIZE 	0x03
+#define ST_M95_WRID             0x82
+#define ST_M95_WRID_OUTSIZE 	0x06
+#define ST_M95_WRID_INSIZE  	0x00
 
 /* Some Atmel AT25F* models have bit 3 as don't care bit in commands */
 #define AT25F_RDID		0x15	/* 0x15 or 0x1d */


### PR DESCRIPTION
 Hi
 It's added support for ST95XXX chips . The following chipsets have been tested for read, erase and write operations:
 [ STM95080  STM95160  STM95320  STM95640  STM95128  STM95256 ]

The chipsets(except st95xxxA125) can't respond with RDID instruction and for this reason was added FEATURE_IDENTITY_MISSING feature. The feature works with "force" option and disable rdid checking during read operation.
Also It's emulates erase operation for chipsets which don't support it.

Known issue: It doesn't support chipset STM95040 because memory size lower then 1K and the chipset has special instruction set for read operation.


Signed-off-by: Nikolay Nikolaev <evrinoma@gmail.com>