### PR TITLE
fixing compile problems on windows 10 using MinGW compiler

### DIFF
--- a/ich_descriptors.c
+++ b/ich_descriptors.c
@@ -15,6 +15,10 @@
  * GNU General Public License for more details.
  */
 
+#if defined(__MINGW32__) || defined(__MINGW64__)
+	#define __USE_MINGW_ANSI_STDIO 1
+#endif
+
 #include "ich_descriptors.h"
 
 #ifdef ICH_DESCRIPTORS_FROM_DUMP_ONLY

--- a/libflashrom.c
+++ b/libflashrom.c
@@ -33,6 +33,25 @@
 #include "ich_descriptors.h"
 #include "libflashrom.h"
 
+#if defined(__MINGW32__) || defined(__MINGW64__)
+char *strndup(const char *str, int chars);
+
+char *strndup(const char *str, int chars)
+{
+    char *buffer;
+    int n;
+
+    buffer = (char *) malloc(chars +1);
+    if (buffer)
+    {
+        for (n = 0; ((n < chars) && (str[n] != 0)) ; n++) buffer[n] = str[n];
+        buffer[n] = 0;
+    }
+
+    return buffer;
+}
+#endif
+
 /**
  * @defgroup flashrom-general General
  * @{


### PR DESCRIPTION
Flashrom does not compile with mingw-w64\i686-7.3.0-win32 compiler. This patch fixes the issues.
