### PR TITLE
linux_spi: add missing include

### DIFF
--- a/linux_spi.c
+++ b/linux_spi.c
@@ -26,6 +26,7 @@
 #include <unistd.h>
 #include <sys/ioctl.h>
 #include <linux/types.h>
+#include <linux/ioctl.h>
 #include <linux/spi/spidev.h>
 #include <linux/ioctl.h>
 #include "flash.h"


### PR DESCRIPTION
Some defines (e.g. _IOC_SIZEBITS) are defined in linux/ioctl.h,
so it must be included before it is used, by SPI_IOC_MESSAGE
from linux/spi/spidev.h

Fixes build errors with the musl C library, as seen in these
Buildroot autobuilder failures:

    http://autobuild.buildroot.org/results/2a3/2a3744007c630c267575a638ebcd83a4b97644f5/build-end.log
    http://autobuild.buildroot.org/results/3de/3de936d9be79e151e66af15193084d82a0f2c04a/build-end.log

Signed-off-by: "Yann E. MORIN" <yann.morin.1998@free.fr>
[Retrieved from:
https://git.buildroot.net/buildroot/tree/package/flashrom/0001-spi.patch]
Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>