### PR TITLE
added BY25D16 - Boya Microelectronics

### DIFF
--- a/flashchips.c
+++ b/flashchips.c
@@ -3403,6 +3403,44 @@ const struct flashchip flashchips[] = {
 		.read		= read_memmapped,
 		.voltage	= {3000, 3600},
 	},
+/* Boya Microelectronics Inc.*/
+        {
+		.vendor		= "Boya Microelectronics Inc.",
+		.name		= "BY25D16",
+		.bustype	= BUS_SPI,
+		.manufacture_id	= BOYA_ID,
+		.model_id	= BOYA_BY25D16,
+		.total_size	= 2048,
+		.page_size	= 256,
+		.feature_bits	= FEATURE_WRSR_WREN,
+		.tested		= TEST_OK_PREW,
+		.probe		= probe_spi_rdid,
+		.probe_timing	= TIMING_ZERO,
+		.block_erasers	=
+		{
+			{
+				.eraseblocks = { {4 * 1024, 512} },
+				.block_erase = spi_block_erase_20,
+			}, {
+				.eraseblocks = { {32 * 1024, 64} },
+				.block_erase = spi_block_erase_52,
+			}, {
+				.eraseblocks = { {64 * 1024, 32} },
+				.block_erase = spi_block_erase_d8,
+			}, {
+				.eraseblocks = { {2 * 1024 * 1024, 1} },
+				.block_erase = spi_block_erase_60,
+			}, {
+				.eraseblocks = { {2 * 1024 * 1024, 1} },
+				.block_erase = spi_block_erase_c7,
+			}
+		},
+		.printlock	= spi_prettyprint_status_register_at25df,
+		.unlock		= spi_disable_blockprotect_at2x_global_unprotect,
+		.write		= spi_chip_write_256,
+		.read		= spi_chip_read,
+		.voltage	= {2700, 3600},
+	},
 
 	{
 		.vendor		= "Bright",

--- a/flashchips.h
+++ b/flashchips.h
@@ -212,6 +212,10 @@
 #define BRIGHT_BM29F400B	0xAB
 #define BRIGHT_BM29F400T	0xAD
 
+/* Boya Microelectronics Inc. */
+#define BOYA_ID			0x68
+#define BOYA_BY25D16		0x4015
+
 #define CATALYST_ID		0x31	/* Catalyst */
 #define CATALYST_CAT28F512	0xB8
 


### PR DESCRIPTION
Change-Id: Ibe24c3dc52c413ce9422deb9045773dfd042f9e0

Added the BY25D16 SPI flash memory in " flashchips.c" and " flashchips.h" and tried it on a FT2232H adapter.