### PR TITLE
libflashrom.h Add includes for types not in all projects

### DIFF
--- a/libflashrom.h
+++ b/libflashrom.h
@@ -20,6 +20,8 @@
 
 #include <sys/types.h>
 #include <stddef.h>
+#include <stdbool.h>
+#include <cstdint.h>
 #include <stdarg.h>
 
 int flashrom_init(int perform_selfcheck);


### PR DESCRIPTION
Fixes this in fwupd:
```
cc -Iplugins/flashrom/1ac62b6@@fu_plugin_flashrom@sha -Iplugins/flashrom -I../plugins/flashrom -Iplugins/flashrom/../.. -I../plugins/flashrom/../.. -Iplugins/flashrom/../../src -I../plugins/flashrom/../../src -Iplugins/flashrom/../../libfwupd -I../plugins/flashrom/../../libfwupd -Isubprojects/flashrom -I../subprojects/flashrom -Isrc -I/usr/include/libxmlb-1 -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/uuid -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -I/usr/include/gio-unix-2.0 -I/usr/include/gusb-1 -I/usr/include/libusb-1.0 -I/usr/include/libsoup-2.4 -I/usr/include/libxml2 -I/usr/include/gudev-1.0 -I/usr/include/x86_64-linux-gnu -I/usr/include/libftdi1 -fdiagnostics-color=always -pipe -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -std=c99 -g -fstack-protector-strong -Waggregate-return -Wunused -Warray-bounds -Wcast-align -Wclobbered -Wdeclaration-after-statement -Wduplicated-branches -Wduplicated-cond -Wempty-body -Wformat=2 -Wformat-nonliteral -Wformat-security -Wformat-signedness -Wignored-qualifiers -Wimplicit-function-declaration -Winit-self -Wlogical-op -Wmissing-declarations -Wmissing-format-attribute -Wmissing-include-dirs -Wmissing-noreturn -Wmissing-parameter-type -Wmissing-prototypes -Wnested-externs -Wno-cast-function-type -Wno-address-of-packed-member -Wno-unknown-pragmas -Wno-deprecated-declarations -Wno-discarded-qualifiers -Wno-missing-field-initializers -Wno-strict-aliasing -Wno-suggest-attribute=format -Wno-unused-parameter -Wnull-dereference -Wold-style-definition -Woverride-init -Wpointer-arith -Wredundant-decls -Wreturn-type -Wshadow -Wsign-compare -Wstrict-aliasing -Wstrict-prototypes -Wswitch-default -Wtype-limits -Wundef -Wuninitialized -Wunused-but-set-variable -Wunused-variable -Wvla -Wwrite-strings -D_DEFAULT_SOURCE -DFWUPD_DISABLE_DEPRECATED -D_BSD_SOURCE -D_XOPEN_SOURCE=700 -fPIC -pthread '-DG_LOG_DOMAIN="FuPluginFlashrom"' '-DLOCALSTATEDIR="/usr/local/var"' -MD -MQ 'plugins/flashrom/1ac62b6@@fu_plugin_flashrom@sha/fu-plugin-flashrom.c.o' -MF 'plugins/flashrom/1ac62b6@@fu_plugin_flashrom@sha/fu-plugin-flashrom.c.o.d' -o 'plugins/flashrom/1ac62b6@@fu_plugin_flashrom@sha/fu-plugin-flashrom.c.o' -c ../plugins/flashrom/fu-plugin-flashrom.c
In file included from ../plugins/flashrom/fu-plugin-flashrom.c:27:
../subprojects/flashrom/libflashrom.h:57:72: error: unknown type name ‘bool’
   57 | void flashrom_flag_set(struct flashrom_flashctx *, enum flashrom_flag, bool value);
      |                                                                        ^~~~
../subprojects/flashrom/libflashrom.h:58:1: error: unknown type name ‘bool’
   58 | bool flashrom_flag_get(const struct flashrom_flashctx *, enum flashrom_flag);
      | ^~~~
../subprojects/flashrom/libflashrom.h:69:37: error: unknown type name ‘uint8_t’
   69 |   struct flashrom_flashctx *, const uint8_t *buf, size_t len);
      |                                     ^~~~~~~
```