### PR TITLE
ft2232_spi: Add support for Tin Can Tools Flyswatter/Flyswatter 2

### DIFF
--- a/flashrom.8.tmpl
+++ b/flashrom.8.tmpl
@@ -756,7 +756,8 @@ Atmel AT25128, AT25256, Micron (ST) M95128, M95256 and OnSemi (Catalyst) CAT25CS
 This module supports various programmers based on FTDI FT2232/FT4232H/FT232H chips including the DLP Design
 DLP-USB1232H, openbiosprog-spi, Amontec JTAGkey/JTAGkey-tiny/JTAGkey-2, Dangerous Prototypes Bus Blaster,
 Olimex ARM-USB-TINY/-H, Olimex ARM-USB-OCD/-H, OpenMoko Neo1973 Debug board (V2+), TIAO/DIYGADGET USB
-Multi-Protocol Adapter (TUMPA), TUMPA Lite, GOEPEL PicoTAP and Google Servo v1/v2.
+Multi-Protocol Adapter (TUMPA), TUMPA Lite, GOEPEL PicoTAP, Google Servo v1/v2 and Tin Can Tools
+Flyswatter/Flyswatter 2.
 .sp
 An optional parameter specifies the controller
 type, channel/interface/port and GPIO-based chip select it should support. For that you have to use the

--- a/ft2232_spi.c
+++ b/ft2232_spi.c
@@ -269,6 +269,12 @@ int ft2232_spi_init(void)
 		} else if (!strcasecmp(arg, "google-servo-v2-legacy")) {
 			ft2232_vid = GOOGLE_VID;
 			ft2232_type = GOOGLE_SERVO_V2_PID0;
+		} else if (!strcasecmp(arg, "flyswatter")) {
+			ft2232_type = FTDI_FT2232H_PID;
+			channel_count = 2;
+			/* Flyswatter and Flyswatter-2 require GPIO bits 0x80
+			 * and 0x40 to be driven low to enable output buffers */
+			pindir = 0xcb;
 		} else {
 			msg_perr("Error: Invalid device type specified.\n");
 			free(arg);


### PR DESCRIPTION
The Tin Can Tools Flyswatter and Flyswatter 2 have a FT2232H
with a  JTAG interface wired to port A. The buffers that drive the
JTAG pins need to be enabled with an nOE signal from the
FT2232H ADBUS6 and ADBUS7 pins.

Flyswatter has an ARM-14 JTAG interface and Flyswatter 2 has
an ARM-20 JTAG interface.

Change-Id: I56b1fb76dcda32bb02980cd54a2853506bfc9dfd
Signed-off-by: Russ Dill <Russ.Dill@gmail.com>