### PR TITLE
flashchips: Add AT25SF321

### DIFF
--- a/flashchips.c
+++ b/flashchips.c
@@ -2331,6 +2331,44 @@ const struct flashchip flashchips[] = {
 
 	{
 		.vendor		= "Atmel",
+		.name		= "AT25SF321",
+		.bustype	= BUS_SPI,
+		.manufacture_id	= ATMEL_ID,
+		.model_id	= ATMEL_AT25SF321,
+		.total_size	= 4096,
+		.page_size	= 256,
+		.feature_bits	= FEATURE_WRSR_WREN,
+		.tested		= TEST_OK_PR,
+		.probe		= probe_spi_rdid,
+		.probe_timing	= TIMING_ZERO,
+		.block_erasers	=
+		{
+			{
+				.eraseblocks = { {4 * 1024, 1024} },
+				.block_erase = spi_block_erase_20,
+			}, {
+				.eraseblocks = { {32 * 1024, 128} },
+				.block_erase = spi_block_erase_52,
+			}, {
+				.eraseblocks = { {64 * 1024, 64} },
+				.block_erase = spi_block_erase_d8,
+			}, {
+				.eraseblocks = { {4096 * 1024, 1} },
+				.block_erase = spi_block_erase_60,
+			}, {
+				.eraseblocks = { {4096 * 1024, 1} },
+				.block_erase = spi_block_erase_c7,
+			}
+		},
+		.printlock	= spi_prettyprint_status_register_plain,
+		.unlock		= spi_disable_blockprotect,
+		.write		= spi_chip_write_256,
+		.read		= spi_chip_read,
+		.voltage	= {2500, 3600},
+	},
+
+	{
+		.vendor		= "Atmel",
 		.name		= "AT25SL128A",
 		.bustype	= BUS_SPI,
 		.manufacture_id	= ATMEL_ID,

--- a/flashchips.h
+++ b/flashchips.h
@@ -150,6 +150,7 @@
 #define ATMEL_AT25SF041		0x8401
 #define ATMEL_AT25SF081		0x8501
 #define ATMEL_AT25SF161		0x8601
+#define ATMEL_AT25SF321		0x8701
 #define ATMEL_AT25SL128A	0x4218
 #define ATMEL_AT26DF041		0x4400
 #define ATMEL_AT26DF081		0x4500	/* guessed, no datasheet available */


### PR DESCRIPTION
This commit adds support for the Adesto AT25SF321 SPI flash chip. Probe
and read operations have been tested via FT2232H interface, but writes
have not been verified.

Datasheet is available at the following URL:
https://www.adestotech.com/wp-content/uploads/DS-AT25SF321_047.pdf

Signed-off-by: Peter Adkins <pete@kernelpicnic.net>