### PR TITLE
dediprog: add serial argument

### DIFF
--- a/flashrom.8.tmpl
+++ b/flashrom.8.tmpl
@@ -928,6 +928,12 @@ can be
 .BR 0V ", " 1.8V ", " 2.5V ", " 3.5V
 or the equivalent in mV.
 .sp
+You can use the
+.B serial
+parameter to explicitly specify which dediprog device should be used
+based on their USB serial number::
+.sp
+.B "  flashrom \-p dediprog:serial=1230A12"
 An optional
 .B device
 parameter specifies which of multiple connected Dediprog devices should be used.


### PR DESCRIPTION
A quick hack to be able to select dediprogs by USB serial argument by
just adding a @serial_number parameter to dediprog_open() and using it
in preference to @id if available (since it is more specific).

Change-Id: I9cdfbce6cf941c16bf7b7364aa4166b91369e661
Signed-off-by: Inaky Perez-Gonzalez <inaky.perez-gonzalez@intel.com>