### PR TITLE
Buspirate spi auxpin

### DIFF
--- a/buspirate_spi.c
+++ b/buspirate_spi.c
@@ -214,6 +214,10 @@ out_shutdown:
  */
 #define BP_DIVISOR(baud) ((4000000/(baud)) - 1)
 
+// Information on the buspirate's Raw Bitbanging and Raw SPI modes used here:
+// http://dangerousprototypes.com/blog/2009/10/09/bus-pirate-raw-bitbang-mode/
+// http://dangerousprototypes.com/blog/2009/10/08/bus-pirate-raw-spi-mode/
+
 int buspirate_spi_init(void)
 {
 	char *tmp;

--- a/flashrom.8.tmpl
+++ b/flashrom.8.tmpl
@@ -898,10 +898,22 @@ where
 .B state
 can be
 .BR on " or " off .
+.sp
 More information about the Bus Pirate pull-up resistors and their purpose is available
 .URLB "http://dangerousprototypes.com/docs/Practical_guide_to_Bus_Pirate_pull-up_resistors" \
 "in a guide by dangerousprototypes" .
 Only the external supply voltage (Vpu) is supported as of this writing.
+.sp
+An optional
+.B auxpin
+parameter specifies the state in which the Bus Pirate's AUX pin is to be held.
+Use this e.g., if you need to hold a reset line low.
+Syntax is
+.sp
+.B "  flashrom -p buspirate_spi:auxpin=state"
+.sp
+where
+.BR state " can be " high " or " low ". The default is " high "."
 .SS
 .BR "pickit2_spi " programmer
 .IP


### PR DESCRIPTION
This change allows using the Bus Pirate's AUX pin to hold a device (e.g., a microcontroller) in reset during SPI transfers.
The old behaviour (high state) is preserved if the parameter is not present.

Change-Id: Ic18cddf8f7c3296eae866a9decd23b0e396d28e3
Signed-off-by: Roman Sommer <roman.sommer@fau.de>