### PR TITLE
typecast enum conversions explicitly

### DIFF
--- a/libflashrom.c
+++ b/libflashrom.c
@@ -188,7 +188,7 @@ struct flashrom_board_info *flashrom_supported_boards(void)
 		for (; i < boards_known_size; ++i) {
 			supported_boards[i].vendor = binfo[i].vendor;
 			supported_boards[i].name = binfo[i].name;
-			supported_boards[i].working = binfo[i].working;
+			supported_boards[i].working = (enum flashrom_test_state)binfo[i].working;
 		}
 	} else {
 		msg_gerr("Memory allocation error!\n");
@@ -226,7 +226,7 @@ struct flashrom_chipset_info *flashrom_supported_chipsets(void)
 			supported_chipsets[i].chipset = chipset[i].device_name;
 			supported_chipsets[i].vendor_id = chipset[i].vendor_id;
 			supported_chipsets[i].chipset_id = chipset[i].device_id;
-			supported_chipsets[i].status = chipset[i].status;
+			supported_chipsets[i].status = (enum flashrom_test_state)chipset[i].status;
 	  }
 	} else {
 		msg_gerr("Memory allocation error!\n");


### PR DESCRIPTION
clang complains like below

libflashrom.c:191:43: error: implicit conversion from enumeration type 'const enum test_state' to different enumeration type 'enum flashrom_test_state' [-Werror,-Wenum-conversion]
                        supported_boards[i].working = binfo[i].working;
                                                    ~ ~~~~~~~~~^~~~~~~
libflashrom.c:229:46: error: implicit conversion from enumeration type 'const enum test_state' to different enumeration type 'enum flashrom_test_state' [-Werror,-Wenum-conversion]
                        supported_chipsets[i].status = chipset[i].status;
                                                     ~ ~~~~~~~~~~~^~~~~~

However these enums are exactly same so they can be typecasted

libflashrom.h

/** @ingroup flashrom-query */
enum flashrom_test_state {
        FLASHROM_TESTED_OK  = 0,
        FLASHROM_TESTED_NT  = 1,
        FLASHROM_TESTED_BAD = 2,
        FLASHROM_TESTED_DEP = 3,
        FLASHROM_TESTED_NA  = 4,
};

flash.h

enum test_state {
          OK = 0,
          NT = 1, /* Not tested */
          BAD,    /* Known to not work */
          DEP,    /* Support depends on configuration (e.g. Intel flash descriptor) */
          NA,     /* Not applicable (e.g. write support on ROM chips) */
  };

Upstream-Status: Pending

Change-Id: If12360e0a2cdbb3cd35bc3c19bdfd74cfe6cac20
Signed-off-by: Khem Raj <raj.khem@gmail.com>