### PR TITLE
udelay.c: Enable providing delay calibration value through CLI

### DIFF
--- a/flashrom.8.tmpl
+++ b/flashrom.8.tmpl
@@ -50,7 +50,7 @@ flashrom \- detect, read, write, verify and erase flash chips
              [\fB\-E\fR|\fB\-r\fR <file>|\fB\-w\fR <file>|\fB\-v\fR <file>]
              [(\fB\-l\fR <file>|\fB\-\-ifd|\fB \-\-fmap\fR|\fB\-\-fmap-file\fR <file>) [\fB\-i\fR <image>]]
              [\fB\-n\fR] [\fB\-N\fR] [\fB\-f\fR])]
-         [\fB\-V\fR[\fBV\fR[\fBV\fR]]] [\fB-o\fR <logfile>]
+         [\fB\-V\fR[\fBV\fR[\fBV\fR]]] [\fB-o\fR <logfile>] [\fB-d\fR get | <value>]
 .SH DESCRIPTION
 .B flashrom
 is a utility for detecting, reading, writing, verifying and erasing flash
@@ -364,6 +364,18 @@ on-screen messages are not verbose and don't require output redirection.
 .TP
 .B "\-R, \-\-version"
 Show version information and exit.
+.TP
+.B "\-d, \-\-delay"
+Retrieve the loop calibration delay value or provide one externally. Calibrate
+delay procedure can take a few seconds and for repeated execution on a large
+number of hosts it can provide a significant overhead. Therefore, this argument
+makes it possible to provide the calibration delay through the command line
+option.
+
+To retrieve the value, run
+.BR "flashrom \--delay get " "and to provide it during programming, add "
+.BR "--delay <value> " "to your command."
+
 .SH PROGRAMMER-SPECIFIC INFORMATION
 Some programmer drivers accept further parameters to set programmer-specific
 parameters. These parameters are separated from the programmer name by a

--- a/programmer.h
+++ b/programmer.h
@@ -277,6 +277,8 @@ void myusec_delay(unsigned int usecs);
 void myusec_calibrate_delay(void);
 void internal_sleep(unsigned int usecs);
 void internal_delay(unsigned int usecs);
+unsigned long get_calibration_value(void);
+void set_external_calibration(unsigned long external_micro);
 
 #if CONFIG_INTERNAL == 1
 /* board_enable.c */

--- a/udelay.c
+++ b/udelay.c
@@ -221,6 +221,25 @@ recalibrate:
 	msg_pinfo("OK.\n");
 }
 
+void set_external_calibration(unsigned long external_micro) {
+	micro = external_micro;
+	unsigned long elapsed = measure_delay(100000);
+
+	/* Do a sanity check if the provided parameter makes loops fall within 10% of
+	   the desired value. Otherwise, ignore provided value and recalibrate. */
+	if (elapsed > 90000 && elapsed < 110000) {
+		msg_pinfo("Provided delay is acceptable!\n");
+	}
+	else {
+		myusec_calibrate_delay();
+	}
+}
+
+unsigned long get_calibration_value(void) {
+	myusec_calibrate_delay();
+	return micro;
+}
+
 /* Not very precise sleep. */
 void internal_sleep(unsigned int usecs)
 {


### PR DESCRIPTION
This commit implements --delay option to retrieve and provide the calibration
loop delay through the command line. The delay calibration procedure can take
up to few seconds, which adds up when executed a number of times consecutively.
Therefore, this provides a means to execute it only once, and then re-use the
calibrated value on subsequent runs. Also, it implements a sanity check,
expecting the value to land within 10% of the theoretical delay expectance,
otherwise it ignores the provided value and runs the calibration procedure
instead.

        modified:   cli_classic.c
        modified:   flashrom.8.tmpl
        modified:   programmer.h
        modified:   udelay.c

Change-Id: Iea2a7f62300663bc0a32ed4abced57c8c55c90c8
Signed-off-by: Hrvoje Cavrak <hrvoje@hrvoje.org>