### PR TITLE
pcidev: On arm64 we are not getting a valid BAR0 address

### DIFF
--- a/programmer.h
+++ b/programmer.h
@@ -193,6 +193,7 @@ struct pci_dev;
 // FIXME: This needs to be local, not global(?)
 extern struct pci_access *pacc;
 int pci_init_common(void);
+int pci_bar_number_from_offset(int offset);
 uintptr_t pcidev_readbar(struct pci_dev *dev, int bar);
 struct pci_dev *pcidev_init(const struct dev_entry *devs, int bar);
 /* rpci_write_* are reversible writes. The original PCI config space register


### PR DESCRIPTION
It seems that there is some code to work around a possible bug in
old versions of libpci. This trusts libpci if it is new enough

Change-Id: I8bd32c6344b0831a949c3853abeb84905420922a
Signed-off-by: Martijn Berger <martijn.berger@gmail.com>