### PR TITLE
Some Meson fixes and enhancements

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -100,6 +100,7 @@ else
   config_developerbox_spi = false
   config_pickit2_spi = false
   config_raiden_debug_spi = false
+  config_stlinkv3_spi = false
 endif
 
 # some programmers require libpci

--- a/meson.build
+++ b/meson.build
@@ -74,6 +74,7 @@ cargs = []
 deps = []
 srcs = []
 
+need_libftdi = false
 need_libpci = false
 need_libusb = false
 need_raw_access = false
@@ -88,6 +89,12 @@ if cc.has_function('strnlen')
 endif
 if cc.check_header('sys/utsname.h')
   add_project_arguments('-DHAVE_UTSNAME=1', language : 'c')
+endif
+
+if get_option('no_libftdi_programmers')
+  message('Disabling ALL libftdi-based programmers')
+  config_ft2232_spi = false
+  config_usbblaster_spi = false
 endif
 
 if get_option('no_libusb_programmers')
@@ -178,8 +185,8 @@ if config_dummy
 endif
 if config_ft2232_spi
   srcs += 'ft2232_spi.c'
+  need_libftdi = true
   cargs += '-DCONFIG_FT2232_SPI=1'
-  deps += dependency('libftdi1')
   cargs += '-DHAVE_FT232H=1'
 endif
 if config_gfxnvidia
@@ -312,8 +319,8 @@ if config_serprog
 endif
 if config_usbblaster_spi
   srcs += 'usbblaster_spi.c'
+  need_libftdi = true
   cargs += '-DCONFIG_USBBLASTER_SPI=1'
-  deps += dependency('libftdi1')
 endif
 if config_stlinkv3_spi
   srcs += 'stlinkv3_spi.c'
@@ -338,6 +345,11 @@ endif
 if host_machine.system() == 'linux'
   srcs += 'i2c_helper_linux.c'
   cargs += '-DCONFIG_I2C_SUPPORT=1'
+endif
+
+# some programmers require libftdi
+if need_libftdi
+  deps += dependency('libftdi1')
 endif
 
 # some programmers require libpci

--- a/meson.build
+++ b/meson.build
@@ -74,6 +74,7 @@ cargs = []
 deps = []
 srcs = []
 
+need_libpci = false
 need_libusb = false
 need_raw_access = false
 need_serial = false
@@ -100,13 +101,8 @@ if get_option('no_libusb_programmers')
   config_stlinkv3_spi = false
 endif
 
-# some programmers require libpci
-if get_option('pciutils')
-  srcs += 'pcidev.c'
-  deps += dependency('libpci')
-  need_raw_access = true
-  cargs += '-DNEED_PCI=1'
-else
+if get_option('no_libpci_programmers')
+  message('Disabling ALL libpci-based programmers')
   config_atahpt = false
   config_atapromise = false
   config_atavia = false
@@ -128,14 +124,17 @@ endif
 # set defines for configured programmers
 if config_atahpt
   srcs += 'atahpt.c'
+  need_libpci = true
   cargs += '-DCONFIG_ATAHPT=1'
 endif
 if config_atapromise
   srcs += 'atapromise.c'
+  need_libpci = true
   cargs += '-DCONFIG_ATAPROMISE=1'
 endif
 if config_atavia
   srcs += 'atavia.c'
+  need_libpci = true
   cargs += '-DCONFIG_ATAVIA=1'
 endif
 if config_buspirate_spi
@@ -170,6 +169,7 @@ if config_jlink_spi
 endif
 if config_drkaiser
   srcs += 'drkaiser.c'
+  need_libpci = true
   cargs += '-DCONFIG_DRKAISER=1'
 endif
 if config_dummy
@@ -184,10 +184,12 @@ if config_ft2232_spi
 endif
 if config_gfxnvidia
   srcs += 'gfxnvidia.c'
+  need_libpci = true
   cargs += '-DCONFIG_GFXNVIDIA=1'
 endif
 if config_raiden_debug_spi
   srcs += 'raiden_debug_spi.c'
+  need_libpci = true
   cargs += '-DCONFIG_RAIDEN_DEBUG_SPI=1'
 endif
 if config_internal
@@ -206,6 +208,7 @@ if config_internal
     srcs += 'sb600spi.c'
     srcs += 'wbsio_spi.c'
   endif
+  need_libpci = true
   config_bitbang_spi = true
   cargs += '-DCONFIG_INTERNAL=1'
   if get_option('config_internal_dmi')
@@ -219,6 +222,7 @@ if config_ene_lpc
 endif
 if config_it8212
   srcs += 'it8212.c'
+  need_libpci = true
   cargs += '-DCONFIG_IT8212=1'
 endif
 if config_linux_mtd
@@ -239,32 +243,39 @@ if config_mstarddc_spi
 endif
 if config_nic3com
   srcs += 'nic3com.c'
+  need_libpci = true
   cargs += '-DCONFIG_NIC3COM=1'
 endif
 if config_nicintel
   srcs += 'nicintel.c'
+  need_libpci = true
   cargs += '-DCONFIG_NICINTEL=1'
 endif
 if config_nicintel_eeprom
   srcs += 'nicintel_eeprom.c'
+  need_libpci = true
   cargs += '-DCONFIG_NICINTEL_EEPROM=1'
 endif
 if config_nicintel_spi
   srcs += 'nicintel_spi.c'
+  need_libpci = true
   config_bitbang_spi = true
   cargs += '-DCONFIG_NICINTEL_SPI=1'
 endif
 if config_nicnatsemi
   srcs += 'nicnatsemi.c'
+  need_libpci = true
   cargs += '-DCONFIG_NICNATSEMI=1'
 endif
 if config_nicrealtek
   srcs += 'nicrealtek.c'
+  need_libpci = true
   cargs += '-DCONFIG_NICREALTEK=1'
 endif
 if config_ogp_spi
   config_bitbang_spi = true
   srcs += 'ogp_spi.c'
+  need_libpci = true
   cargs += '-DCONFIG_OGP_SPI=1'
 endif
 if config_pickit2_spi
@@ -286,10 +297,12 @@ if config_rayer_spi
 endif
 if config_satamv
   srcs += 'satamv.c'
+  need_libpci = true
   cargs += '-DCONFIG_SATAMV=1'
 endif
 if config_satasii
   srcs += 'satasii.c'
+  need_libpci = true
   cargs += '-DCONFIG_SATASII=1'
 endif
 if config_serprog
@@ -325,6 +338,14 @@ endif
 if host_machine.system() == 'linux'
   srcs += 'i2c_helper_linux.c'
   cargs += '-DCONFIG_I2C_SUPPORT=1'
+endif
+
+# some programmers require libpci
+if need_libpci
+  srcs += 'pcidev.c'
+  deps += dependency('libpci')
+  need_raw_access = true
+  cargs += '-DNEED_PCI=1'
 endif
 
 # some programmers require libusb

--- a/meson.build
+++ b/meson.build
@@ -74,6 +74,7 @@ cargs = []
 deps = []
 srcs = []
 
+need_libusb = false
 need_raw_access = false
 need_serial = false
 
@@ -88,12 +89,8 @@ if cc.check_header('sys/utsname.h')
   add_project_arguments('-DHAVE_UTSNAME=1', language : 'c')
 endif
 
-# some programmers require libusb
-if get_option('usb')
-  srcs += 'usbdev.c'
-  srcs += 'usb_device.c'
-  deps += dependency('libusb-1.0')
-else
+if get_option('no_libusb_programmers')
+  message('Disabling ALL libusb-based programmers')
   config_ch341a_spi = false
   config_dediprog = false
   config_digilent_spi = false
@@ -148,18 +145,22 @@ if config_buspirate_spi
 endif
 if config_ch341a_spi
   srcs += 'ch341a_spi.c'
+  need_libusb = true
   cargs += '-DCONFIG_CH341A_SPI=1'
 endif
 if config_dediprog
   srcs += 'dediprog.c'
+  need_libusb = true
   cargs += '-DCONFIG_DEDIPROG=1'
 endif
 if config_developerbox_spi
   srcs += 'developerbox_spi.c'
+  need_libusb = true
   cargs += '-DCONFIG_DEVELOPERBOX_SPI=1'
 endif
 if config_digilent_spi
   srcs += 'digilent_spi.c'
+  need_libusb = true
   cargs += '-DCONFIG_DIGILENT_SPI=1'
 endif
 if config_jlink_spi
@@ -268,6 +269,7 @@ if config_ogp_spi
 endif
 if config_pickit2_spi
   srcs += 'pickit2_spi.c'
+  need_libusb = true
   cargs += '-DCONFIG_PICKIT2_SPI=1'
 endif
 if config_pony_spi
@@ -302,6 +304,7 @@ if config_usbblaster_spi
 endif
 if config_stlinkv3_spi
   srcs += 'stlinkv3_spi.c'
+  need_libusb = true
   cargs += '-DCONFIG_STLINKV3_SPI=1'
 endif
 if config_lspcon_i2c_spi
@@ -322,6 +325,13 @@ endif
 if host_machine.system() == 'linux'
   srcs += 'i2c_helper_linux.c'
   cargs += '-DCONFIG_I2C_SUPPORT=1'
+endif
+
+# some programmers require libusb
+if need_libusb
+  srcs += 'usbdev.c'
+  srcs += 'usb_device.c'
+  deps += dependency('libusb-1.0')
 endif
 
 # raw memory, MSR or PCI port I/O access

--- a/meson.build
+++ b/meson.build
@@ -298,6 +298,7 @@ endif
 if config_usbblaster_spi
   srcs += 'usbblaster_spi.c'
   cargs += '-DCONFIG_USBBLASTER_SPI=1'
+  deps += dependency('libftdi1')
 endif
 if config_stlinkv3_spi
   srcs += 'stlinkv3_spi.c'

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,5 +1,5 @@
 option('pciutils', type : 'boolean', value : true, description : 'use pciutils')
-option('usb', type : 'boolean', value : true, description : 'use libusb1')
+option('no_libusb_programmers', type : 'boolean', value : false, description : 'disable all programmers depending on libusb')
 option('print_wiki', type : 'boolean', value : true,  description : 'Print Wiki')
 
 option('config_atahpt', type : 'boolean', value : false, description : 'Highpoint (HPT) ATA/RAID controllers')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,3 +1,4 @@
+option('no_libftdi_programmers', type : 'boolean', value : false, description : 'disable all programmers depending on libftdi')
 option('no_libpci_programmers', type : 'boolean', value : false, description : 'disable all programmers depending on libpci')
 option('no_libusb_programmers', type : 'boolean', value : false, description : 'disable all programmers depending on libusb')
 option('print_wiki', type : 'boolean', value : true,  description : 'Print Wiki')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,4 +1,4 @@
-option('pciutils', type : 'boolean', value : true, description : 'use pciutils')
+option('no_libpci_programmers', type : 'boolean', value : false, description : 'disable all programmers depending on libpci')
 option('no_libusb_programmers', type : 'boolean', value : false, description : 'disable all programmers depending on libusb')
 option('print_wiki', type : 'boolean', value : true,  description : 'Print Wiki')
 


### PR DESCRIPTION
A handful of changes I have noticed Meson scripts still needed to get closer to feature parity with the Makefile:
 * make it actually possible to build flashrom with the bitbang_spi back-end disabled;
 * fix dependencies of drivers utilising raw hardware access;
 * fix dependencies of stlinkv3_spi and usbblaster_spi;
 * make it possible to enable jlink_spi;
 * make the group-wide off switches for libusb and libpci programmers stay more in sync with options for individual programmers;
 * introduce similar group logic for libftdi programmers.