### PR TITLE
Added XMC25QH6A chip support

### DIFF
--- a/flashchips.c
+++ b/flashchips.c
@@ -18671,7 +18671,7 @@ const struct flashchip flashchips[] = {
 		.name		= "XM25QH64A",
 		.bustype	= BUS_SPI,
 		.manufacture_id	= XMC_ID,
-		.model_id	= XMC-XM25QH64A,
+		.model_id	= XMC_XM25QH64A,
 		.total_size	= 8192,
 		.page_size	= 256,
 		/* supports SFDP */

--- a/flashchips.c
+++ b/flashchips.c
@@ -18666,6 +18666,47 @@ const struct flashchip flashchips[] = {
 		.write		= NULL,
 	},
 
+	{
+		.vendor		= "XMC",
+		.name		= "XM25QH64A",
+		.bustype	= BUS_SPI,
+		.manufacture_id	= XMC_ID,
+		.model_id	= XMC-XM25QH64A,
+		.total_size	= 8192,
+		.page_size	= 256,
+		/* supports SFDP */
+		/* OTP: 512B total; enter 0x3A */
+		/* QPI enable 0x38, disable 0xFF */
+		.feature_bits	= FEATURE_WRSR_WREN | FEATURE_OTP | FEATURE_QPI,
+		.tested		= TEST_OK_PREW,
+		.probe		= probe_spi_rdid,
+		.probe_timing	= TIMING_ZERO,
+		.block_erasers	=
+		{
+			{
+				.eraseblocks = { {4 * 1024, 2048} },
+				.block_erase = spi_block_erase_20,
+			}, {
+                .eraseblocks = { {32 * 1024, 256} },
+                .block_erase = spi_block_erase_52,
+            }, {
+				.eraseblocks = { {64 * 1024, 128} },
+				.block_erase = spi_block_erase_d8,
+			}, {
+				.eraseblocks = { { 8192 * 1024, 1} },
+				.block_erase = spi_block_erase_60,
+			}, {
+				.eraseblocks = { { 8192 * 1024, 1} },
+				.block_erase = spi_block_erase_c7,
+			}
+		},
+		.printlock	= spi_prettyprint_status_register_bp3_srwd, /* bit6 is quad enable */
+		.unlock		= spi_disable_blockprotect_bp3_srwd,
+		.write		= spi_chip_write_256,
+		.read		= spi_chip_read,
+		.voltage	= {2700, 3600},
+	},
+
 	{0}
 };
 

--- a/flashchips.h
+++ b/flashchips.h
@@ -993,4 +993,21 @@
 #define ZETTADEVICE_ZD25D20     0x2012
 #define ZETTADEVICE_ZD25D40     0x2013
 
+#define XMC_ID          0x20    /* same as ST_ID */
+#define XMC_XM25QH256B  0x6019
+#define XMC_XM25QH128A  0x1708
+#define XMC_XM25QH128B  0x6018
+#define XMC_XM25QH64A   0x7017
+#define XMC_XM25QH64B   0x6017
+#define XMC_XM25QH32B   0x4016  /* 0x6016 for QPI mode */
+#define XMC_XM25QH16B   0x4015
+#define XMC_XM25QH80B   0x4014
+#define XMC_XM25QH40B   0x4013
+#define XMC_XM25QU256B  0x7019
+#define XMC_XM25QU128B  0x5018
+#define XMC_XM25QU64A   0x3817
+#define XMC_XM25QU64B   0x5017
+#define XMC_XM25QU40B   0x5013
+#define XMC_XM25QU20B   0x5012
+
 #endif /* !FLASHCHIPS_H */


### PR DESCRIPTION
I was facing issues in reading the chip and created an issue https://github.com/flashrom/flashrom/issues/148. Since, it wasn't getting any attention, I added the support for the XMC chip I was facing issues with and I tested it and I was able to read and write and detect without any issues.