### PR TITLE
meson: fix compilation under uClibc-ng

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -25,7 +25,7 @@ conf = configuration_data()
 cc = meson.get_compiler('c')
 add_project_arguments(cc.get_supported_arguments(warning_flags), language : 'c')
 add_project_arguments('-D_DEFAULT_SOURCE', language : 'c')
-add_project_arguments('-D_POSIX_C_SOURCE', language : 'c') # required for fileno
+add_project_arguments('-D_POSIX_C_SOURCE=200809L', language : 'c') # required for fileno, nanosleep, and strndup
 add_project_arguments('-D_BSD_SOURCE', language : 'c') # required for glibc < v2.19
 add_project_arguments('-DFLASHROM_VERSION="' + meson.project_version() + '"', language : 'c')
 


### PR DESCRIPTION
fileno requires _POSIX_C_SOURCE to only be defined.

nanosleep requires _POSIX_C_SOURCE to be defined to 199309L.

strndup requires _POSIX_C_SOURCE to be defined to 200809L.

Signed-off-by: Rosen Penev <rosenp@gmail.com>