### PR TITLE
Add support for BY25Q128AS - Boya Micro Microelectronics

### DIFF
--- a/flashchips.c
+++ b/flashchips.c
@@ -3441,6 +3441,45 @@ const struct flashchip flashchips[] = {
 		.read		= read_memmapped,
 		.voltage	= {3000, 3600},
 	},
+	
+    	{
+		.vendor		= "BOYAMICRO",
+		.name		= "BY25Q128AS",
+		.bustype	= BUS_SPI,
+		.manufacture_id	= BOYAMICRO_ID,
+		.model_id	= BOYAMICRO_BY25Q128AS,
+		.total_size	= 131072,
+		.page_size	= 256,
+
+		.feature_bits	= FEATURE_WRSR_WREN | FEATURE_QPI | FEATURE_OTP | FEATURE_4BA_ENTER_WREN | FEATURE_4BA_EXT_ADDR | FEATURE_4BA_READ | FEATURE_4BA_FAST_READ,
+		.tested		= TEST_OK_PREW,
+		.probe		= probe_spi_rdid,
+		.probe_timing	= TIMING_ZERO,
+		.block_erasers	=
+		{
+			{
+				.eraseblocks = { {4 * 1024, 32768} },
+				.block_erase = spi_block_erase_20,
+			}, {
+				.eraseblocks = { {32 * 1024, 4096} },
+				.block_erase = spi_block_erase_52,
+			}, {
+				.eraseblocks = { {64 * 1024, 2048} },
+				.block_erase = spi_block_erase_d8,
+			}, {
+				.eraseblocks = { {128 * 1024 * 1024, 1} },
+				.block_erase = spi_block_erase_60,
+			}, {
+				.eraseblocks = { {128 * 1024 * 1024, 1} },
+				.block_erase = spi_block_erase_c7,
+			}
+		},
+		.printlock	= spi_prettyprint_status_register_plain,
+		.unlock		= spi_disable_blockprotect_at2x_global_unprotect,
+		.write		= spi_chip_write_256,
+		.read		= spi_chip_read,
+		.voltage	= {1800, 3600},
+	},
 
 	{
 		.vendor		= "Bright",

--- a/flashchips.h
+++ b/flashchips.h
@@ -207,6 +207,10 @@
 #define ATMEL_AT49F080		0x23
 #define ATMEL_AT49F080T		0x27
 
+/* Boya Microelectronics Inc.*/
+#define BOYAMICRO_ID        	0x68
+#define BOYAMICRO_BY25Q128AS    0x4018
+
 /* Bright Microelectronics has the same manufacturer ID as Hyundai... */
 #define BRIGHT_ID		0xAD	/* Bright Microelectronics */
 #define BRIGHT_BM29F040		0x40


### PR DESCRIPTION
This contrib adds support for BY25Q128AS (128Mb) - Boya Micro Microelectronics. I have tested it and dumped firmware using this code, and this chip.