### PR TITLE
flashchips: Mark Intel 25F640S33B8 as TESTED_PREW

### DIFF
--- a/flashchips.c
+++ b/flashchips.c
@@ -7503,7 +7503,7 @@ const struct flashchip flashchips[] = {
 		.page_size	= 256,
 		/* OTP: 506B total (2x 8B, 30x 16B, 1x 10B); read 0x4B; write 0x42 */
 		.feature_bits	= FEATURE_WRSR_WREN | FEATURE_OTP,
-		.tested		= TEST_UNTESTED,
+		.tested		= TEST_OK_PREW,
 		.probe		= probe_spi_rdid,
 		.probe_timing	= TIMING_ZERO,
 		.block_erasers	=


### PR DESCRIPTION
Tested with ch341a_spi from an Atheros AP81 reference board.

Signed-off-by: Zoltan HERPAI <wigyori@uid0.hu>