### PR TITLE
Add Intel B365 chipset support

### DIFF
--- a/chipset_enable.c
+++ b/chipset_enable.c
@@ -2054,6 +2054,7 @@ const struct penable chipset_enables[] = {
 	{0x8086, 0xa2c7, B_S,    NT,  "Intel", "Q250",				enable_flash_pch100},
 	{0x8086, 0xa2c8, B_S,    NT,  "Intel", "B250",				enable_flash_pch100},
 	{0x8086, 0xa2c9, B_S,    NT,  "Intel", "Z370",				enable_flash_pch100},
+	{0x8086, 0xa2cc, B_S,    NT,  "Intel", "B365",				enable_flash_pch100},
 	{0x8086, 0xa2d2, B_S,    NT,  "Intel", "X299",				enable_flash_pch100},
 	{0x8086, 0x5ae8, B_S,    DEP, "Intel", "Apollo Lake",			enable_flash_apl},
 	{0x8086, 0x5af0, B_S,    DEP, "Intel", "Apollo Lake",			enable_flash_apl},


### PR DESCRIPTION
Add a new PCH device ID for B365.
Thanks!