### PR TITLE
Add support for BrightMoon T25S40

### DIFF
--- a/flashchips.c
+++ b/flashchips.c
@@ -3546,6 +3546,44 @@ const struct flashchip flashchips[] = {
 	},
 
 	{
+		.vendor         = "BrightMoon",
+		.name	        = "T25S40",
+		.bustype	= BUS_SPI,
+		.manufacture_id = 0x5e,
+		.model_id       = 0x2013,
+		.total_size     = 512,
+		.page_size      = 256,
+		.feature_bits   = FEATURE_WRSR_WREN,
+		.tested	        = TEST_OK_PREW,
+		.probe          = probe_spi_rdid,
+		.probe_timing   = TIMING_ZERO,
+		.block_erasers  =
+		{
+			{
+				.eraseblocks = { {4 * 1024, 128} },
+				.block_erase = spi_block_erase_20,
+			}, {
+				.eraseblocks = { {32 * 1024, 16} },
+				.block_erase = spi_block_erase_52,
+			}, {
+				.eraseblocks = { {64 * 1024, 8} },
+				.block_erase = spi_block_erase_d8,
+			}, {
+				.eraseblocks = { {512 * 1024, 1} },
+				.block_erase = spi_block_erase_60,
+			}, {
+				.eraseblocks = { {512 * 1024, 1} },
+				.block_erase = spi_block_erase_c7,
+			}
+		},
+		.printlock      = spi_prettyprint_status_register_bp3_srwd,
+		.unlock	        = spi_disable_blockprotect_bp3_srwd,
+		.write	        = spi_chip_write_256,
+		.read	        = spi_chip_read, /* Fast read (0x0B), dual I/O read (0x3B) supported */
+		.voltage        = {2700, 3600},
+	},
+
+	{
 		.vendor		= "Catalyst",
 		.name		= "CAT28F512",
 		.bustype	= BUS_PARALLEL,


### PR DESCRIPTION
I misflashed / had a broken uPD720201 which used a BrightMoon T25S40 that identified as 0x5e/0x2013?

Rumors said it would be similar to the N25S40, so I gave the settings a try, adjusted it a bit based on the datasheet and it flashed without issues. I haven't done more than reviving a single card so I can't guarantee more but it worked.

Change-Id: Ia47e015aca092c2886703fdce1ff793246e1fc24
Signed-off-by: René Treffer <treffer@measite.de>