### PR TITLE
flashchips: Add ZB25VQ64

### DIFF
--- a/flashchips.c
+++ b/flashchips.c
@@ -19394,6 +19394,44 @@ const struct flashchip flashchips[] = {
 	},
 
 	{
+		.vendor		= "Zbit",
+		.name		= "ZB25V64",
+		.bustype	= BUS_SPI,
+		.manufacture_id	= ZBIT_ID,
+		.model_id	= ZBIT_ZB25VQ64_V,
+		.total_size	= 8192,
+		.page_size	= 256,
+		.feature_bits	= FEATURE_WRSR_WREN,
+		.tested		= TEST_UNTESTED,
+		.probe		= probe_spi_rdid,
+		.probe_timing	= TIMING_ZERO,
+		.block_erasers	=
+		{
+			{
+				.eraseblocks = { {4 * 1024, 2048} },
+				.block_erase = spi_block_erase_20,
+			}, {
+				.eraseblocks = { {32 * 1024, 256} },
+				.block_erase = spi_block_erase_52,
+			}, {
+				.eraseblocks = { {64 * 1024, 128} },
+				.block_erase = spi_block_erase_d8,
+			}, {
+				.eraseblocks = { {8 * 1024 * 1024, 1} },
+				.block_erase = spi_block_erase_60,
+			}, {
+				.eraseblocks = { {8 * 1024 * 1024, 1} },
+				.block_erase = spi_block_erase_c7,
+			}
+		},
+		.printlock	= spi_prettyprint_status_register_plain, /* TODO: improve */
+		.unlock		= spi_disable_blockprotect,
+		.write		= spi_chip_write_256,
+		.read		= spi_chip_read,
+		.voltage	= {2700, 3600},
+	},
+
+	{
 		.vendor		= "Zetta Device",
 		.name		= "ZD25D20",
 		.bustype	= BUS_SPI,
@@ -19638,6 +19676,21 @@ const struct flashchip flashchips[] = {
 		.name		= "unknown Winbond (ex Nexcom) SPI chip",
 		.bustype	= BUS_SPI,
 		.manufacture_id	= WINBOND_NEX_ID,
+		.model_id	= GENERIC_DEVICE_ID,
+		.total_size	= 0,
+		.page_size	= 256,
+		.tested		= TEST_BAD_PREW,
+		.probe		= probe_spi_rdid,
+		.probe_timing	= TIMING_ZERO,
+		.write		= NULL,
+		.read		= NULL,
+	},
+
+	{
+		.vendor		= "Zbit",
+		.name		= "unknown Zbit SPI chip",
+		.bustype	= BUS_SPI,
+		.manufacture_id	= ZBIT_ID,
 		.model_id	= GENERIC_DEVICE_ID,
 		.total_size	= 0,
 		.page_size	= 256,

--- a/flashchips.h
+++ b/flashchips.h
@@ -1025,6 +1025,10 @@
 #define WINBOND_W49V002A	0xB0
 #define WINBOND_W49V002FA	0x32
 
+#define ZBIT_ID             0x5E    /* Zbit Semiconductor */
+#define ZBIT_ZB25VQ64_V     0x4017  /* SPI */
+#define ZBIT_ZB25VQ64_Q     0x6017  /* QPI */
+
 #define ZETTADEVICE_ID          0xBA	/* Zetta Device */
 #define ZETTADEVICE_ZD25D20     0x2012
 #define ZETTADEVICE_ZD25D40     0x2013


### PR DESCRIPTION
The ZB25VQ64 seems to be a clone of the W25Q64FV. Only tested reading
and it seems to work. Verified my nand dump against a partition dump,
using sha1, and it came back as a match.

Change-Id: Idc85084f97275d295c801d982ab47ce3f3358fa3
Signed-off-by: Bkacjios <blackops7799@gmail.com>