### PR TITLE
Add support for Spansion S25FL064L Flash device.

### DIFF
--- a/flashchips.c
+++ b/flashchips.c
@@ -16069,6 +16069,35 @@ const struct flashchip flashchips[] = {
 
 	{
 		.vendor		= "Spansion",
+		.name		= "S25FL064L",
+		.bustype	= BUS_SPI,
+		.manufacture_id	= SPANSION_ID,
+		.model_id	= SPANSION_S25FL064L,
+		.total_size	= 8192,
+		.page_size	= 256,
+		.feature_bits	= FEATURE_WRSR_WREN,
+		.tested		= TEST_OK_PREW,
+		.probe		= probe_spi_rdid,
+		.probe_timing	= TIMING_ZERO,
+		.block_erasers	=
+		{
+			{
+				.eraseblocks = { {64 * 1024, 128} },
+				.block_erase = spi_block_erase_d8,
+			}, {
+				.eraseblocks = { {8 * 1024 * 1024, 1} },
+				.block_erase = spi_block_erase_c7,
+			}
+		},
+		.printlock	= spi_prettyprint_status_register_plain, /* TODO: improve */
+		.unlock		= spi_disable_blockprotect,
+		.write		= spi_chip_write_256,
+		.read		= spi_chip_read,
+		.voltage	= {2700, 3600},
+	},
+
+	{
+		.vendor		= "Spansion",
 		.name		= "S25FL116K/S25FL216K", /* FIXME: separate them */
 		.bustype	= BUS_SPI,
 		.manufacture_id	= SPANSION_ID,

--- a/flashchips.h
+++ b/flashchips.h
@@ -659,6 +659,7 @@
 #define SPANSION_S25FL016A	0x0214
 #define SPANSION_S25FL032A	0x0215	/* Same as S25FL032P, but the latter supports EDI and CFI */
 #define SPANSION_S25FL064A	0x0216	/* Same as S25FL064P, but the latter supports EDI and CFI */
+#define SPANSION_S25FL064L	0x6017	/* Inherited from Cypress Semiconductor */
 #define SPANSION_S25FL128	0x2018	/* Same ID for various S25FL127S, S25FL128P, S25FL128S and S25FL129P (including dual-die S70FL256P) variants (EDI supported) */
 #define SPANSION_S25FL256	0x0219
 #define SPANSION_S25FL512	0x0220

--- a/it87spi.c
+++ b/it87spi.c
@@ -77,7 +77,14 @@ static uint16_t probe_id_ite(uint16_t port)
 	enter_conf_mode_ite(port);
 	id = sio_read(port, CHIP_ID_BYTE1_REG) << 8;
 	id |= sio_read(port, CHIP_ID_BYTE2_REG);
-	exit_conf_mode_ite(port);
+
+// modification to prevent console kill on NetBoard-A8 (Microchip SCH3221 LPC UART)
+	if (id == 0x3C00) {
+		msg_pdbg("Found SMSC SCH3221 chip. Closing config mode alternatively.\n");
+		OUTB(0xAA, port); // Exit config mode of SCH3221
+	}
+	else
+		exit_conf_mode_ite(port); // normal exit for ITE devices
 
 	return id;
 }


### PR DESCRIPTION
Add support for Spansion S25FL064L Flash device.
Also, a patch is added to prevent UART shutdown on SMSC SCH3221 devices when probing for ITE devices.