### PR TITLE
Add ST M95P16 16mbit SPI flash chip

### DIFF
--- a/flashchips.c
+++ b/flashchips.c
@@ -15924,6 +15924,45 @@ const struct flashchip flashchips[] = {
 	},
 
 	{
+		.vendor		= "ST",
+		.name		= "M95P16",
+		.bustype	= BUS_SPI,
+		.manufacture_id	= ST_ID,
+		.model_id	= ST_M95P16,
+		.total_size	= 2048,
+		.page_size	= 512,
+		.feature_bits	= FEATURE_WRSR_WREN,
+		.tested		= TEST_UNTESTED,
+		.probe		= PROBE_SPI_ST95,
+		.probe_timing	= TIMING_ZERO,
+		.block_erasers	=
+		{
+			{
+				.eraseblocks = { {512, 4096} },
+				.block_erase = SPI_BLOCK_ERASE_DB,
+			},
+			{
+				.eraseblocks = { {4 * 1024, 512} },
+				.block_erase = SPI_BLOCK_ERASE_20,
+			},
+			{
+				.eraseblocks = { {64 * 1024, 32} },
+				.block_erase = SPI_BLOCK_ERASE_D8,
+			},
+			{
+				.eraseblocks = { {2 * 1024 * 1024, 1} },
+				.block_erase = SPI_BLOCK_ERASE_C7,
+			}
+
+		},
+		.printlock	= SPI_PRETTYPRINT_STATUS_REGISTER_BP1_SRWD,
+		.unlock		= SPI_DISABLE_BLOCKPROTECT_BP1_SRWD,
+		.write		= SPI_CHIP_WRITE256,
+		.read		= SPI_CHIP_READ,
+		.voltage	= {2500, 5500},
+	},
+
+	{
 		.vendor		= "Sanyo",
 		.name		= "LE25FU106B",
 		.bustype	= BUS_SPI,

--- a/include/flashchips.h
+++ b/include/flashchips.h
@@ -897,6 +897,7 @@
 #define ST_M58WR064KT		0x8810
 
 #define ST_M95M02		0x0012	/* ST M95XXX 2Mbit (256KiB) */
+#define ST_M95P16		0x0015	/* ST M95P16 16Mbit (4096KiB) */
 
 #define ST_MT28GU01G___1	0x88B0
 #define ST_MT28GU01G___2	0x88B1


### PR DESCRIPTION
This `M95P16` is a newish 16mbit chip from ST which has 512-byte pages instead of the usual 256-byte. The datasheet is here: https://www.st.com/resource/en/datasheet/m95p16-i.pdf

I didn't understand all of these settings, but after setting up this configuration I was able to erase, program, and verify the contents using a FTDI232H interface.

I'm sure there are errors in this config but I will present this as a starting point.