### PR TITLE
Add Boya/BoMong BY25D40A

### DIFF
--- a/flashchips.c
+++ b/flashchips.c
@@ -3605,6 +3605,44 @@ const struct flashchip flashchips[] = {
 		.voltage	= {2700, 3600},
 	},
 
+        {
+                .vendor         = "Boya/BoHong Microelectronics",
+                .name           = "B.25D40A",
+                .bustype        = BUS_SPI,
+                .manufacture_id = BOYA_BOHONG_ID,
+                .model_id       = BOYA_BOHONG_B__25D40A,
+                .total_size     = 512,
+                .page_size      = 256,
+                .feature_bits   = FEATURE_WRSR_WREN,
+                .tested         = TEST_OK_PR,
+                .probe          = PROBE_SPI_RDID,
+                .probe_timing   = TIMING_ZERO,
+                .block_erasers  =
+                {
+                        {
+                                .eraseblocks = { {4 * 512, 256} },
+                                .block_erase = SPI_BLOCK_ERASE_20,
+                        }, {
+                                .eraseblocks = { {32 * 512, 32} },
+                                .block_erase = SPI_BLOCK_ERASE_52,
+                        }, {
+                                .eraseblocks = { {64 * 512, 16} },
+                                .block_erase = SPI_BLOCK_ERASE_D8,
+                        }, {
+                                .eraseblocks = { {1 * 512 * 1024, 1} },
+                                .block_erase = SPI_BLOCK_ERASE_60,
+                        }, {
+                                .eraseblocks = { {1 * 512 * 1024, 1} },
+                                .block_erase = SPI_BLOCK_ERASE_C7,
+                        }
+                },
+                .printlock      = SPI_PRETTYPRINT_STATUS_REGISTER_BP2_SRWD,
+                .unlock         = SPI_DISABLE_BLOCKPROTECT_BP2_SRWD,
+                .write          = SPI_CHIP_WRITE256,
+                .read           = SPI_CHIP_READ,
+                .voltage        = {2700, 3600},
+        },
+
 	{
 		.vendor		= "Boya/BoHong Microelectronics",
 		.name		= "B.25Q128AS",

--- a/include/flashchips.h
+++ b/include/flashchips.h
@@ -211,6 +211,7 @@
 
 /* Boya/BoHong Microelectronics Inc. */
 #define BOYA_BOHONG_ID		0x68
+#define BOYA_BOHONG_B__25D40A   0x4013
 #define BOYA_BOHONG_B__25D80A	0x4014
 #define BOYA_BOHONG_B_25D16A	0x4015
 #define BOYA_BOHONG_B_25Q128AS	0x4018


### PR DESCRIPTION
Add BY25D40A, is 512KB SPI
Device ID is 0x4013
Datasheet avaliable there: https://datasheet.lcsc.com/lcsc/1912111437_BOYAMICRO-BY25D40ASTIG-T_C384591.pdf

Signed-off-by: Giammarco Marzano [stich86@gmail.com](mailto:stich86@gmail.com)