### PR TITLE
Adding pci vendor and model identifier to support the Intel C256 Chip…

### DIFF
--- a/chipset_enable.c
+++ b/chipset_enable.c
@@ -2174,6 +2174,7 @@ const struct penable chipset_enables[] = {
 	{0x8086, 0x4389, B_S,    NT,  "Intel", "WM590",				enable_flash_pch500},
 	{0x8086, 0x438a, B_S,    NT,  "Intel", "QM580",				enable_flash_pch500},
 	{0x8086, 0x438b, B_S,    DEP, "Intel", "HM570",				enable_flash_pch500},
+	{0x8086, 0x4c43, B_S,    NT,  "Intel", "C256 Chipset",                  enable_flash_c620},
 	{0x8086, 0x54a4, B_S,    DEP, "Intel", "Alder Lake-N",			enable_flash_pch600},
 	{0x8086, 0x51a4, B_S,    DEP, "Intel", "Alder Lake-P",			enable_flash_pch600},
 	{0x8086, 0x7a87, B_S,    NT,  "Intel", "H610",				enable_flash_pch600},


### PR DESCRIPTION
…set in the Supermicro sys-510t-mr.