### PR TITLE
ft2232_spi: Add Digilent JTAG-SMT2/-NC programmer

### DIFF
--- a/doc/classic_cli_manpage.rst
+++ b/doc/classic_cli_manpage.rst
@@ -875,9 +875,9 @@ ft2232_spi programmer
 ^^^^^^^^^^^^^^^^^^^^^
 
 This module supports various programmers based on FTDI FT2232/FT4232H/FT232H chips including the DLP Design DLP-USB1232H,
-openbiosprog-spi, Amontec JTAGkey/JTAGkey-tiny/JTAGkey-2, Dangerous Prototypes Bus Blaster, Olimex ARM-USB-TINY/-H,
-Olimex ARM-USB-OCD/-H, OpenMoko Neo1973 Debug board (V2+), TIAO/DIYGADGET USB Multi-Protocol Adapter (TUMPA), TUMPA Lite,
-GOEPEL PicoTAP, Google Servo v1/v2, Tin Can Tools Flyswatter/Flyswatter 2 and Kristech KT-LINK.
+openbiosprog-spi, Amontec JTAGkey/JTAGkey-tiny/JTAGkey-2, Dangerous Prototypes Bus Blaster, Digilent JTAG-SMT2/-NC,
+Olimex ARM-USB-TINY/-H, Olimex ARM-USB-OCD/-H, OpenMoko Neo1973 Debug board (V2+), TIAO/DIYGADGET USB Multi-Protocol
+Adapter (TUMPA), TUMPA Lite, GOEPEL PicoTAP, Google Servo v1/v2, Tin Can Tools Flyswatter/Flyswatter 2 and Kristech KT-LINK.
 
 An optional parameter specifies the controller type, channel/interface/port it should support. For that you have to use the::
 


### PR DESCRIPTION
I needed a 1.8V capable SPI programmer.
Found an old Digilent module, wired it with LDOs for 3.3 VDD and 1.8V VREF.
Found its internal documentation and made the flashrom to work with it.

Pre-tested on oscilloscope to see CS#, DI, CLK transitioning before connecting to board.

Worked on first try on ASUS Pro-Art X570 Creator WiFi, equipped with w25q256jweq memory.
No CPU was installed, and the 1.8V SPI region powered through the TPM port.
> Found Winbond flash chip "W25Q256JW" (32768 kB, SPI).

Reading (at divider 16 and 64 match), and wrote new contents.

NOTE: the module has default VID:PID and the model table (devs_ft2232spi) therefore has duplicate entries, I assume auto-detection would pick the first (non Digilent) entry for FT232H, and those who want to use this programmer need to explicitly specify it like:

`flashrom --programmer ft2232_spi:type=jtag-smt2,divisor=16`