### PR TITLE
Add support for BYTe Semiconductor's BY25D40ES

### DIFF
--- a/flashchips/boya_bohong.c
+++ b/flashchips/boya_bohong.c
@@ -11,6 +11,44 @@
  */
 
 	{
+		.vendor		= "BYTe Semiconductor",
+		.name		= "BY25D40ES",
+		.bustype	= BUS_SPI,
+		.manufacture_id	= BOYA_BOHONG_ID,
+		.model_id	= BOYA_BOHONG_BY25D40ES,
+		.total_size	= 512,
+		.page_size	= 256,
+		.feature_bits	= FEATURE_WRSR_WREN,
+		.tested		= TEST_OK_PR,
+		.probe		= PROBE_SPI_RDID,
+		.probe_timing	= TIMING_ZERO,
+		.block_erasers	=
+		{
+			{
+				.eraseblocks = { {4 * 1024, 128} },
+				.block_erase = SPI_BLOCK_ERASE_20,
+			}, {
+				.eraseblocks = { {32 * 1024, 16} },
+				.block_erase = SPI_BLOCK_ERASE_52,
+			}, {
+				.eraseblocks = { {64 * 1024, 8} },
+				.block_erase = SPI_BLOCK_ERASE_D8,
+			}, {
+				.eraseblocks = { {512 * 1024, 1} },
+				.block_erase = SPI_BLOCK_ERASE_60,
+			}, {
+				.eraseblocks = { {512 * 1024, 1} },
+				.block_erase = SPI_BLOCK_ERASE_C7,
+			}
+		},
+		.printlock	= SPI_PRETTYPRINT_STATUS_REGISTER_BP2_SRWD,
+		.unlock		= SPI_DISABLE_BLOCKPROTECT_BP2_SRWD,
+		.write		= SPI_CHIP_WRITE256,
+		.read		= SPI_CHIP_READ,
+		.voltage	= {2700, 3600},
+	},
+
+	{
 		.vendor		= "Boya/BoHong Microelectronics",
 		.name		= "B.25D16A",
 		.bustype	= BUS_SPI,

--- a/include/flashchips.h
+++ b/include/flashchips.h
@@ -200,8 +200,9 @@
 #define ATMEL_AT49F080		0x23
 #define ATMEL_AT49F080T		0x27
 
-/* Boya/BoHong Microelectronics Inc. */
+/* Boya/BoHong Microelectronics Inc. / BYTe Semiconductor */
 #define BOYA_BOHONG_ID		0x68
+#define BOYA_BOHONG_BY25D40ES	0x4013
 #define BOYA_BOHONG_B__25D80A	0x4014
 #define BOYA_BOHONG_B_25D16A	0x4015
 #define BOYA_BOHONG_B_25Q64AS	0x4017


### PR DESCRIPTION
Add definition of BYTe Semiconductor's BY25D40ES
Datasheet: https://byte-semi.com/wp-content/uploads/BY25D40ES.pdf