### PR TITLE
Add XTX write-protect range support

### DIFF
--- a/flashchips/xtx.c
+++ b/flashchips/xtx.c
@@ -47,6 +47,55 @@
 
 	{
 		.vendor		= "XTX Technology Limited",
+		.name		= "XT25F16B",
+		.bustype	= BUS_SPI,
+		.manufacture_id	= XTX_ID,
+		.model_id	= XTX_XT25F16B,
+		.total_size	= 2 * 1024,
+		.page_size	= 256,
+		/* Supports SFDP */
+		/* OTP: 4 x 256 bytes */
+		.feature_bits	= FEATURE_WRSR_WREN | FEATURE_WRSR2 | FEATURE_OTP | FEATURE_QPI,
+		.tested		= TEST_UNTESTED,
+		.probe		= PROBE_SPI_RDID,
+		.probe_timing	= TIMING_ZERO,
+		.block_erasers	=
+		{
+			{
+				.eraseblocks = { {4 * 1024, 512} },
+				.block_erase = SPI_BLOCK_ERASE_20,
+			}, {
+				.eraseblocks = { {32 * 1024, 64} },
+				.block_erase = SPI_BLOCK_ERASE_52,
+			}, {
+				.eraseblocks = { {64 * 1024, 32} },
+				.block_erase = SPI_BLOCK_ERASE_D8,
+			}, {
+				.eraseblocks = { {2 * 1024 * 1024, 1} },
+				.block_erase = SPI_BLOCK_ERASE_60,
+			}, {
+				.eraseblocks = { {2 * 1024 * 1024, 1} },
+				.block_erase = SPI_BLOCK_ERASE_C7,
+			}
+		},
+		.printlock	= SPI_PRETTYPRINT_STATUS_REGISTER_BP4_SRWD,
+		.unlock		= SPI_DISABLE_BLOCKPROTECT_BP4_SRWD,
+		.write		= SPI_CHIP_WRITE256,
+		.read		= SPI_CHIP_READ,
+		.voltage	= {2700, 3600},
+		.reg_bits	=
+		{
+			.srp	= {STATUS1, 7, RW},
+			.srl	= {STATUS2, 0, RW},
+			.bp	= {{STATUS1, 2, RW}, {STATUS1, 3, RW}, {STATUS1, 4, RW},
+				   {STATUS1, 5, RW}, {STATUS1, 6, RW}},
+			.cmp	= {STATUS2, 6, RW},
+		},
+		.decode_range	= DECODE_RANGE_SPI25_XTX,
+	},
+
+	{
+		.vendor		= "XTX Technology Limited",
 		.name		= "XT25F64B",
 		.bustype	= BUS_SPI,
 		.manufacture_id	= XTX_ID,
@@ -55,7 +104,7 @@
 		.page_size	= 256,
 		/* Supports SFDP */
 		/* OTP: 4 x 256 bytes */
-		.feature_bits	= FEATURE_WRSR_WREN | FEATURE_OTP | FEATURE_QPI,
+		.feature_bits	= FEATURE_WRSR_WREN | FEATURE_WRSR2 | FEATURE_OTP | FEATURE_QPI,
 		.tested		= TEST_OK_PREW,
 		.probe		= PROBE_SPI_RDID,
 		.probe_timing	= TIMING_ZERO,
@@ -83,6 +132,15 @@
 		.write		= SPI_CHIP_WRITE256,
 		.read		= SPI_CHIP_READ,
 		.voltage	= {2700, 3600},
+		.reg_bits	=
+		{
+			.srp	= {STATUS1, 7, RW},
+			.srl	= {STATUS2, 0, RW},
+			.bp	= {{STATUS1, 2, RW}, {STATUS1, 3, RW}, {STATUS1, 4, RW},
+				   {STATUS1, 5, RW}, {STATUS1, 6, RW}},
+			.cmp	= {STATUS2, 6, RW},
+		},
+		.decode_range	= DECODE_RANGE_SPI25_XTX,
 	},
 
 	{
@@ -95,7 +153,7 @@
 		.page_size	= 256,
 		/* Supports SFDP */
 		/* OTP: 4 x 256 bytes */
-		.feature_bits	= FEATURE_WRSR_WREN | FEATURE_OTP | FEATURE_QPI,
+		.feature_bits	= FEATURE_WRSR_WREN | FEATURE_WRSR2 | FEATURE_OTP | FEATURE_QPI,
 		.tested		= TEST_OK_PREW,
 		.probe		= PROBE_SPI_RDID,
 		.probe_timing	= TIMING_ZERO,
@@ -123,4 +181,13 @@
 		.write		= SPI_CHIP_WRITE256,
 		.read		= SPI_CHIP_READ,
 		.voltage	= {2700, 3600},
+		.reg_bits	=
+		{
+			.srp	= {STATUS1, 7, RW},
+			.srl	= {STATUS2, 0, RW},
+			.bp	= {{STATUS1, 2, RW}, {STATUS1, 3, RW}, {STATUS1, 4, RW},
+				   {STATUS1, 5, RW}, {STATUS1, 6, RW}},
+			.cmp	= {STATUS2, 6, RW},
+		},
+		.decode_range	= DECODE_RANGE_SPI25_XTX,
 	},

--- a/include/chipdrivers.h
+++ b/include/chipdrivers.h
@@ -164,5 +164,6 @@ void decode_range_spi25(size_t *start, size_t *len, const struct wp_bits *, size
 void decode_range_spi25_64k_block(size_t *start, size_t *len, const struct wp_bits *, size_t chip_len);
 void decode_range_spi25_bit_cmp(size_t *start, size_t *len, const struct wp_bits *, size_t chip_len);
 void decode_range_spi25_2x_block(size_t *start, size_t *len, const struct wp_bits *, size_t chip_len);
+void decode_range_spi25_xtx(size_t *start, size_t *len, const struct wp_bits *, size_t chip_len);
 
 #endif /* !__CHIPDRIVERS_H__ */

--- a/include/flash.h
+++ b/include/flash.h
@@ -240,6 +240,7 @@ enum decode_range_func {
 	DECODE_RANGE_SPI25_64K_BLOCK = 2,
 	DECODE_RANGE_SPI25_BIT_CMP = 3,
 	DECODE_RANGE_SPI25_2X_BLOCK = 4,
+	DECODE_RANGE_SPI25_XTX = 5,
 };
 typedef void (decode_range_func_t)(size_t *start, size_t *len, const struct wp_bits *, size_t chip_len);
 

--- a/include/flashchips.h
+++ b/include/flashchips.h
@@ -1110,6 +1110,7 @@
 
 #define XTX_ID			0x0B	/* XTX Technology Limited */
 #define XTX_XT25F02E		0x4012
+#define XTX_XT25F16B		0x4015
 #define XTX_XT25F64B		0x4017
 #define XTX_XT25F128B		0x4018
 

--- a/include/writeprotect.h
+++ b/include/writeprotect.h
@@ -14,7 +14,7 @@
 
 #include "libflashrom.h"
 
-#define MAX_BP_BITS 4
+#define MAX_BP_BITS 5
 
 /* Chip protection range: start address and length. */
 struct wp_range {

--- a/tests/chip_wp.c
+++ b/tests/chip_wp.c
@@ -101,6 +101,27 @@ static const struct flashchip chip_W25Q128_V = {
 	.decode_range	= DECODE_RANGE_SPI25,
 };
 
+static const struct flashchip chip_XT25F16B = {
+	.vendor		= "XTX Technology Limited",
+	.name		= "XT25F16B",
+	.total_size	= 2 * 1024,
+	.page_size	= 256,
+	.tested		= TEST_UNTESTED,
+	.read		= SPI_CHIP_READ,
+	.write		= SPI_CHIP_WRITE256,
+	.unlock		= SPI_DISABLE_BLOCKPROTECT_BP4_SRWD,
+	.feature_bits	= FEATURE_WRSR_WREN | FEATURE_WRSR2,
+	.reg_bits	=
+	{
+		.srp	= {STATUS1, 7, RW},
+		.srl	= {STATUS2, 0, RW},
+		.bp	= {{STATUS1, 2, RW}, {STATUS1, 3, RW}, {STATUS1, 4, RW},
+			   {STATUS1, 5, RW}, {STATUS1, 6, RW}},
+		.cmp	= {STATUS2, 6, RW},
+	},
+	.decode_range	= DECODE_RANGE_SPI25_XTX,
+};
+
 /* Trying to set an unsupported WP range fails */
 void invalid_wp_range_dummyflasher_test_success(void **state)
 {
@@ -387,6 +408,46 @@ void wp_get_register_values_and_masks(void **state)
 	assert_int_equal(0xfc, write_masks[STATUS1]);
 	assert_int_equal(0x41, write_masks[STATUS2]);
 	assert_int_equal(0x04, write_masks[STATUS3]);
+
+	teardown(NULL);
+
+	flashrom_wp_cfg_release(wp_cfg);
+}
+
+void xtx_wp_range_decode_dummyflasher_test_success(void **state)
+{
+	(void) state; /* unused */
+
+	const size_t chip_len = chip_XT25F16B.total_size * KiB;
+	struct flashrom_flashctx flash = { 0 };
+	struct flashchip mock_chip = chip_XT25F16B;
+	struct flashrom_wp_cfg *wp_cfg;
+	size_t start, len;
+
+	setup_chip(&flash, NULL, &mock_chip, "bus=spi,emulate=W25Q128FV,spi_status=0x4004");
+
+	assert_int_equal(0, flashrom_wp_cfg_new(&wp_cfg));
+	assert_int_equal(0, flashrom_wp_read_cfg(wp_cfg, &flash));
+	flashrom_wp_get_range(&start, &len, wp_cfg);
+
+	/* CMP=1 with BP=001 complements the top 1/32 range. */
+	assert_int_equal(0, start);
+	assert_int_equal(chip_len - 64 * KiB, len);
+
+	flashrom_wp_set_mode(wp_cfg, FLASHROM_WP_MODE_HARDWARE);
+	flashrom_wp_set_range(wp_cfg, chip_len - 64 * KiB, 64 * KiB);
+
+	uint8_t reg_values[MAX_REGISTERS];
+	uint8_t bit_masks[MAX_REGISTERS];
+	uint8_t write_masks[MAX_REGISTERS];
+	assert_int_equal(0, wp_cfg_to_reg_values(reg_values, bit_masks, write_masks, &flash, wp_cfg));
+
+	assert_int_equal(0x84, reg_values[STATUS1]);
+	assert_int_equal(0x00, reg_values[STATUS2]);
+	assert_int_equal(0xfc, bit_masks[STATUS1]);
+	assert_int_equal(0x41, bit_masks[STATUS2]);
+	assert_int_equal(0xfc, write_masks[STATUS1]);
+	assert_int_equal(0x41, write_masks[STATUS2]);
 
 	teardown(NULL);
 

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -603,6 +603,7 @@ int main(int argc, char *argv[])
 		cmocka_unit_test(full_chip_erase_with_wp_dummyflasher_test_success),
 		cmocka_unit_test(partial_chip_erase_with_wp_dummyflasher_test_success),
 		cmocka_unit_test(wp_get_register_values_and_masks),
+		cmocka_unit_test(xtx_wp_range_decode_dummyflasher_test_success),
 	};
 	ret |= cmocka_run_group_tests_name("chip_wp.c tests", chip_wp_tests, NULL, NULL);
 

--- a/tests/tests.h
+++ b/tests/tests.h
@@ -123,6 +123,7 @@ void wp_init_from_status_dummyflasher_test_success(void **state);
 void full_chip_erase_with_wp_dummyflasher_test_success(void **state);
 void partial_chip_erase_with_wp_dummyflasher_test_success(void **state);
 void wp_get_register_values_and_masks(void **state);
+void xtx_wp_range_decode_dummyflasher_test_success(void **state);
 
 /* selfcheck.c */
 void selfcheck_programmer_table(void **state);

--- a/writeprotect.c
+++ b/writeprotect.c
@@ -231,6 +231,7 @@ static decode_range_func_t *lookup_decode_range_func_ptr(const struct flashchip 
 		case DECODE_RANGE_SPI25_64K_BLOCK: return &decode_range_spi25_64k_block;
 		case DECODE_RANGE_SPI25_BIT_CMP: return &decode_range_spi25_bit_cmp;
 		case DECODE_RANGE_SPI25_2X_BLOCK: return &decode_range_spi25_2x_block;
+		case DECODE_RANGE_SPI25_XTX: return &decode_range_spi25_xtx;
 	/* default: total function, 0 indicates no decode range function set. */
 		case NO_DECODE_RANGE_FUNC: return NULL;
 	};

--- a/writeprotect_ranges.c
+++ b/writeprotect_ranges.c
@@ -134,3 +134,48 @@ void decode_range_spi25_2x_block(size_t *start, size_t *len, const struct wp_bit
 	decode_range_generic(start, len, bits, chip_len,
 			     /*fixed_block_len=*/false, /*apply_cmp_to_bp=*/false, /*coeff_offset=*/0);
 }
+
+/*
+ * XTX XT25F-B chips encode top/bottom and block/sector protection in
+ * BP4..BP0 rather than exposing separate TB and SEC bits.
+ */
+void decode_range_spi25_xtx(size_t *start, size_t *len, const struct wp_bits *bits, size_t chip_len)
+{
+	const size_t bp0 = bits->bp_bit_count > 0 ? bits->bp[0] : 0;
+	const size_t bp1 = bits->bp_bit_count > 1 ? bits->bp[1] : 0;
+	const size_t bp2 = bits->bp_bit_count > 2 ? bits->bp[2] : 0;
+	const size_t bp3 = bits->bp_bit_count > 3 ? bits->bp[3] : 0;
+	const size_t bp4 = bits->bp_bit_count > 4 ? bits->bp[4] : 0;
+	const size_t bp = bp0 | (bp1 << 1) | (bp2 << 2);
+	const bool cmp = bits->cmp_bit_present && bits->cmp == 1;
+
+	*start = 0;
+	*len = 0;
+
+	if (bp == 0) {
+		*len = 0;
+	} else if ((bp & 0x06) == 0x06) {
+		*len = chip_len;
+	} else if (bp4 == 0) {
+		*len = min(chip_len >> (6 - bp), chip_len);
+		*start = bp3 ? 0 : chip_len - *len;
+	} else {
+		*len = min((size_t)4 * KiB << min(bp - 1, (size_t)3), chip_len);
+		*start = bp3 ? 0 : chip_len - *len;
+	}
+
+	if (cmp) {
+		if (*len == 0) {
+			*len = chip_len;
+		} else if (*len == chip_len) {
+			*start = 0;
+			*len = 0;
+		} else if (*start == 0) {
+			*start = *len;
+			*len = chip_len - *len;
+		} else {
+			*len = *start;
+			*start = 0;
+		}
+	}
+}


### PR DESCRIPTION
This adds write-protect range support for XTX XT25F-B parts and adds an XT25F16B entry.

XTX uses BP4..BP0 for both the top/bottom selection and the small block ranges, instead of exposing separate TB/SEC bits like the generic SPI25 decoder expects. This adds a small decoder for that layout, allows the WP framework to track five BP bits, and wires XT25F16B/64B/128B to the new decoder.

I also added a dummyflasher test for the XTX path. It covers reading a CMP-complemented range from SR1/SR2 and generating the register values/masks for a top 64 KiB hardware-protected range.

Testing:
- `git diff --check`
- local smoke check for the XTX protection table cases: none, upper/lower 1/32, upper 4 KiB, lower 32 KiB, full-chip, and CMP complement
- minimal MinGW/Meson build reached the changed C files (`writeprotect.c`, `writeprotect_ranges.c`, `tests/chip_wp.c`); full unit test linking could not be completed on this Windows machine because of local MinGW/cmocka environment issues

I do not have an XT25F16B device on hand, so the chip entry is left as `TEST_UNTESTED`.

Related to #185.